### PR TITLE
Add command to add a tag to contact

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTagCommand.java
@@ -1,0 +1,133 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Adds a tag to an existing person in the address book, if the tag does not exist.
+ */
+public class AddTagCommand extends Command {
+
+    public static final String COMMAND_WORD = "tag";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a tag to the tags of an existing contact, "
+            + "as specified by the index number used in the displayed person list. The tag will be added only if "
+            + "the tag is valid and is not already tagged to the contact (case-insensitive).\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + "[" + PREFIX_TAG + "TAG]\n"
+            + "Example: " + COMMAND_WORD + " 2 "
+            + PREFIX_TAG + "friends";
+
+    public static final String MESSAGE_ADD_TAG_SUCCESS = "Added tag: %1$s";
+    public static final String MESSAGE_DUPLICATE_TAG = "This person is already tagged to %1$s.";
+
+    private final Index index;
+    private final Tag tag;
+
+    /**
+     * Constructs an {@code AddTagCommand} with the given {@code Index} and {@code Tag}.
+     *
+     * @param index of the person in the filtered person list to add the {@code Tag}.
+     * @param tag to be tagged to the {@code Person} specified by {@code index}.
+     */
+    public AddTagCommand(Index index, Tag tag) {
+        requireNonNull(index);
+        requireNonNull(tag);
+
+        this.index = index;
+        this.tag = tag;
+    }
+
+    /**
+     * Adds a tag to an existing person in the address book, if the tag does not exist.
+     *
+     * @param model {@code Model} which the command should operate on.
+     * @return the command result after the command execution.
+     * @throws CommandException if the {@code Tag} already exists or the {@code Index} is invalid.
+     */
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToEdit = lastShownList.get(index.getZeroBased());
+
+        if (personToEdit.hasTag(this.tag)) {
+            throw new CommandException(String.format(MESSAGE_DUPLICATE_TAG, this.tag));
+        }
+
+        Person editedPerson = createPersonWithAddedTag(personToEdit, this.tag);
+
+        model.setPerson(personToEdit, editedPerson);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+
+        return new CommandResult(String.format(MESSAGE_ADD_TAG_SUCCESS, editedPerson));
+    }
+
+    /**
+     * Creates and returns a {@code Person} with the details of personToEdit {@code Person}
+     * added with tagToAdd {@code Tag}.
+     */
+    private static Person createPersonWithAddedTag(Person personToEdit, Tag tagToAdd) {
+        assert personToEdit != null;
+
+        Name updatedName = personToEdit.getName();
+        Phone updatedPhone = personToEdit.getPhone();
+        Email updatedEmail = personToEdit.getEmail();
+        Address updatedAddress = personToEdit.getAddress();
+        Set<Tag> updatedTags = addTagToSet(personToEdit.getTags(), tagToAdd);
+
+        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags);
+    }
+
+    /**
+     * Adds a {Tag} to a tag set by creating a new {@code HashSet} (immutable).
+     *
+     * @param tags the tag set to add a {@code Tag} to.
+     * @param tagToAdd the {@code Tag} to be added.
+     * @return an immutable tag set consisting of the existing {@code Tag} and {@code tagToAdd} (only unique tags).
+     */
+    private static Set<Tag> addTagToSet(Set<Tag> tags, Tag tagToAdd) {
+        Set<Tag> updatedTags = new HashSet<>(tags);
+        updatedTags.add(tagToAdd);
+        return Collections.unmodifiableSet(updatedTags);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AddTagCommand)) {
+            return false;
+        }
+
+        // state check
+        AddTagCommand e = (AddTagCommand) other;
+        return this.index.equals(e.index)
+                && this.tag.equals(e.tag);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddTagCommandParser.java
@@ -1,0 +1,45 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.AddTagCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Parses input arguments and creates a new {@code AddTagCommand} object.
+ */
+public class AddTagCommandParser implements Parser<AddTagCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the {@code AddTagCommand}
+     * and returns an {@code AddCommand} object for execution.
+     *
+     * @param args the {@code String} of arguments to be parsed.
+     * @returns the created {@code AddTagCommand} object.
+     * @throws ParseException if the user input does not conform the expected format.
+     */
+    public AddTagCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argumentMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TAG);
+
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(argumentMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddTagCommand.MESSAGE_USAGE), pe);
+        }
+
+        if (argumentMultimap.getValue(PREFIX_TAG).isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddTagCommand.MESSAGE_USAGE));
+        }
+
+        Tag tag = ParserUtil.parseTag(argumentMultimap.getValue(PREFIX_TAG).get());
+
+        return new AddTagCommand(index, tag);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -7,6 +7,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AddTagCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
@@ -68,6 +69,9 @@ public class AddressBookParser {
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();
+
+        case AddTagCommand.COMMAND_WORD:
+            return new AddTagCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/test/java/seedu/address/logic/commands/AddTagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddTagCommandTest.java
@@ -1,0 +1,179 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.AddTagCommand.MESSAGE_DUPLICATE_TAG;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FOURTH_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.model.tag.Tag;
+import seedu.address.testutil.PersonBuilder;
+
+class AddTagCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void constructor_anyFieldsNull_throwsNullPointerException() {
+        Tag tag = new Tag("foo");
+        assertThrows(NullPointerException.class, () -> new AddTagCommand(null, tag));
+        assertThrows(NullPointerException.class, () -> new AddTagCommand(INDEX_FIRST_PERSON, null));
+        assertThrows(NullPointerException.class, () -> new AddTagCommand(null, null));
+    }
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Tag tag = new Tag("foo");
+
+        assert model.getFilteredPersonList().size() > 3;
+
+        Person personToAddTag = model.getFilteredPersonList().get(INDEX_FOURTH_PERSON.getZeroBased());
+        Person expectedPerson = new PersonBuilder(personToAddTag).addTags("foo").build();
+
+        AddTagCommand addTagCommand = new AddTagCommand(INDEX_FOURTH_PERSON, tag);
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.setPerson(model.getFilteredPersonList().get(INDEX_FOURTH_PERSON.getZeroBased()),
+                expectedPerson);
+
+        String expectedMessage = String.format(AddTagCommand.MESSAGE_ADD_TAG_SUCCESS, expectedPerson);
+
+        assertCommandSuccess(addTagCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_duplicatedTagUnfilteredList_throwsCommandException() {
+        // same tag
+        Tag tag = new Tag("friends");
+        Person personToAddTag = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+
+        // Alice must already have the tag "friends"
+        assertTrue(personToAddTag.hasTag(tag));
+
+        AddTagCommand addTagCommand = new AddTagCommand(INDEX_FIRST_PERSON, tag);
+        String expectedMessage = String.format(MESSAGE_DUPLICATE_TAG, tag);
+        assertCommandFailure(addTagCommand, model, expectedMessage);
+
+        // case sensitivity test
+        tag = new Tag("fRiEnDs");
+        addTagCommand = new AddTagCommand(INDEX_FIRST_PERSON, tag);
+        expectedMessage = String.format(MESSAGE_DUPLICATE_TAG, tag);
+        assertCommandFailure(addTagCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getAddressBook().getPersonList().size() + 10);
+
+        // ensures that outOfBoundIndex is out bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() >= model.getAddressBook().getPersonList().size());
+
+        AddTagCommand addTagCommand = new AddTagCommand(outOfBoundIndex, new Tag("randomTag"));
+
+        assertCommandFailure(addTagCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        Tag tag = new Tag("foo");
+
+        Person personToAddTag = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person expectedPerson = new PersonBuilder(personToAddTag).addTags("foo").build();
+
+        AddTagCommand addTagCommand = new AddTagCommand(INDEX_FIRST_PERSON, tag);
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.setPerson(model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()),
+                expectedPerson);
+
+        String expectedMessage = String.format(AddTagCommand.MESSAGE_ADD_TAG_SUCCESS, expectedPerson);
+
+        assertCommandSuccess(addTagCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_duplicatedTagFilteredList_throwsCommandException() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        // same tag
+        Tag tag = new Tag("friends");
+        Person personToAddTag = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+
+        // Alice must already have the tag "friends"
+        assertTrue(personToAddTag.hasTag(tag));
+
+        AddTagCommand addTagCommand = new AddTagCommand(INDEX_FIRST_PERSON, tag);
+        String expectedMessage = String.format(MESSAGE_DUPLICATE_TAG, tag);
+        assertCommandFailure(addTagCommand, model, expectedMessage);
+
+        // case sensitivity test
+        tag = new Tag("fRiEnDs");
+        addTagCommand = new AddTagCommand(INDEX_FIRST_PERSON, tag);
+        expectedMessage = String.format(MESSAGE_DUPLICATE_TAG, tag);
+        assertCommandFailure(addTagCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+
+        AddTagCommand addTagCommand = new AddTagCommand(outOfBoundIndex, new Tag("randomTag"));
+
+        assertCommandFailure(addTagCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        Index firstIndex = Index.fromOneBased(1);
+        Index secondIndex = Index.fromOneBased(2);
+
+        Tag firstTag = new Tag("first");
+        Tag secondTag = new Tag("second");
+
+        AddTagCommand addTagFirstCommand = new AddTagCommand(firstIndex, firstTag);
+        AddTagCommand addTagSecondCommand = new AddTagCommand(secondIndex, firstTag);
+        AddTagCommand addTagThirdCommand = new AddTagCommand(firstIndex, secondTag);
+        AddTagCommand addTagFourthCommand = new AddTagCommand(secondIndex, secondTag);
+
+        // same object -> returns true
+        assertTrue(addTagFirstCommand.equals(addTagFirstCommand));
+
+        // same values -> returns true
+        AddTagCommand addTagFirstCommandCopy = new AddTagCommand(firstIndex, firstTag);
+        assertTrue(addTagFirstCommand.equals(addTagFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(addTagFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(addTagFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(addTagFirstCommand.equals(addTagSecondCommand));
+        assertFalse(addTagFirstCommand.equals(addTagThirdCommand));
+        assertFalse(addTagFirstCommand.equals(addTagFourthCommand));
+        assertFalse(addTagSecondCommand.equals(addTagThirdCommand));
+        assertFalse(addTagSecondCommand.equals(addTagFourthCommand));
+        assertFalse(addTagThirdCommand.equals(addTagFourthCommand));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddTagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddTagCommandParserTest.java
@@ -1,0 +1,91 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.AddTagCommand;
+import seedu.address.model.tag.Tag;
+
+class AddTagCommandParserTest {
+
+    private static final String TAG_EMPTY = " " + PREFIX_TAG;
+
+    private static final String MESSAGE_INVALID_FORMAT =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddTagCommand.MESSAGE_USAGE);
+
+    private AddTagCommandParser parser = new AddTagCommandParser();
+
+    @Test
+    public void parse_noTag_failure() {
+        assertParseFailure(parser, "1", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidTag_failure() {
+        assertParseFailure(parser, "1" + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + TAG_EMPTY + "hubby*", Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + TAG_EMPTY + "hubby and me", Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + TAG_EMPTY + "hubby and me" + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_noIndex_failure() {
+        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, TAG_EMPTY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, TAG_EMPTY + "hubby*", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, TAG_EMPTY + "hubby and me", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, TAG_EMPTY + "hubby and me" + TAG_EMPTY, MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidIndex_failure() {
+        assertParseFailure(parser, "string" + TAG_EMPTY + VALID_TAG_FRIEND, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "*(" + TAG_EMPTY + VALID_TAG_FRIEND, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "*(12sz" + TAG_EMPTY + VALID_TAG_FRIEND, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "0" + TAG_EMPTY + VALID_TAG_FRIEND, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "-1" + TAG_EMPTY + VALID_TAG_FRIEND, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1 1" + TAG_EMPTY + VALID_TAG_FRIEND, MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_allFieldsSpecified_success() {
+        // vanilla
+        AddTagCommand expectedCommand = new AddTagCommand(INDEX_FIRST_PERSON, new Tag(VALID_TAG_FRIEND));
+        assertParseSuccess(parser, INDEX_FIRST_PERSON.getOneBased() + TAG_EMPTY + VALID_TAG_FRIEND, expectedCommand);
+
+        // trailing and leading whitespaces
+        expectedCommand = new AddTagCommand(INDEX_FIRST_PERSON, new Tag(VALID_TAG_FRIEND));
+        assertParseSuccess(parser, " \n \t  " + INDEX_FIRST_PERSON.getOneBased() + TAG_EMPTY
+                + VALID_TAG_FRIEND + " \n \t  ", expectedCommand);
+
+        // leading spaces in tag
+        expectedCommand = new AddTagCommand(INDEX_FIRST_PERSON, new Tag(VALID_TAG_FRIEND));
+        assertParseSuccess(parser, "  \n \t " + INDEX_FIRST_PERSON.getOneBased() + TAG_EMPTY + " \n \t  "
+                + VALID_TAG_FRIEND + " \n \t  ", expectedCommand);
+    }
+
+    @Test
+    public void parse_multipleTag_acceptsLast() {
+        // two different tags
+        AddTagCommand expectedCommand = new AddTagCommand(INDEX_FIRST_PERSON, new Tag(VALID_TAG_FRIEND));
+        assertParseSuccess(parser, INDEX_FIRST_PERSON.getOneBased() + TAG_EMPTY + VALID_TAG_HUSBAND
+                + TAG_EMPTY + VALID_TAG_FRIEND, expectedCommand);
+
+        // two same tags
+        expectedCommand = new AddTagCommand(INDEX_FIRST_PERSON, new Tag(VALID_TAG_FRIEND));
+        assertParseSuccess(parser, INDEX_FIRST_PERSON.getOneBased() + TAG_EMPTY + VALID_TAG_FRIEND
+                + TAG_EMPTY + VALID_TAG_FRIEND, expectedCommand);
+
+        // three tags
+        expectedCommand = new AddTagCommand(INDEX_FIRST_PERSON, new Tag(VALID_TAG_HUSBAND));
+        assertParseSuccess(parser, INDEX_FIRST_PERSON.getOneBased() + TAG_EMPTY + VALID_TAG_FRIEND
+                + TAG_EMPTY + VALID_TAG_FRIEND + TAG_EMPTY + VALID_TAG_HUSBAND, expectedCommand);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddTagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddTagCommandParserTest.java
@@ -3,6 +3,9 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -52,6 +55,16 @@ class AddTagCommandParserTest {
         assertParseFailure(parser, "0" + TAG_EMPTY + VALID_TAG_FRIEND, MESSAGE_INVALID_FORMAT);
         assertParseFailure(parser, "-1" + TAG_EMPTY + VALID_TAG_FRIEND, MESSAGE_INVALID_FORMAT);
         assertParseFailure(parser, "1 1" + TAG_EMPTY + VALID_TAG_FRIEND, MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_additionalPrefix_failure() {
+        assertParseFailure(parser, PREFIX_ADDRESS + "address " + INDEX_FIRST_PERSON.getOneBased()
+                + TAG_EMPTY + VALID_TAG_FRIEND, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, INDEX_FIRST_PERSON.getOneBased() + TAG_EMPTY + VALID_TAG_FRIEND
+                + PREFIX_EMAIL + "email", Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, INDEX_FIRST_PERSON.getOneBased() + " " + PREFIX_PHONE + "phone"
+                + TAG_EMPTY + VALID_TAG_FRIEND, MESSAGE_INVALID_FORMAT);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,6 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
@@ -14,6 +17,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AddTagCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
@@ -81,9 +85,17 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_hashtag() throws Exception {
-        Tag tag = new Tag("foo");
-        HashtagCommand command = (HashtagCommand) parser.parseCommand(HashtagCommand.COMMAND_WORD + "foo");
+        Tag tag = new Tag(VALID_TAG_HUSBAND);
+        HashtagCommand command = (HashtagCommand) parser.parseCommand(HashtagCommand.COMMAND_WORD + VALID_TAG_HUSBAND);
         assertEquals(new HashtagCommand(new PersonWithTagPredicate(tag)), command);
+    }
+
+    @Test
+    public void parseCommand_addTag() throws Exception {
+        Tag tag = new Tag(VALID_TAG_FRIEND);
+        AddTagCommand command = (AddTagCommand) parser.parseCommand(AddTagCommand.COMMAND_WORD + " "
+                + INDEX_FIRST_PERSON.getOneBased() + " " + PREFIX_TAG + VALID_TAG_FRIEND);
+        assertEquals(new AddTagCommand(INDEX_FIRST_PERSON, tag), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -66,6 +66,20 @@ public class PersonBuilder {
     }
 
     /**
+     * Parses the {@code tags} into a {@code Set<Tag>} and add it to the tag set of {@code Person}
+     * that we are building.
+     *
+     * @param tags the tags to add to the tag set.
+     * @return this {@code PersonBuilder}.
+     */
+    public PersonBuilder addTags(String ... tags) {
+        Set<Tag> newSet = new HashSet<>(this.tags);
+        newSet.addAll(SampleDataUtil.getTagSet(tags));
+        this.tags = newSet;
+        return this;
+    }
+
+    /**
      * Sets the {@code Address} of the {@code Person} that we are building.
      */
     public PersonBuilder withAddress(String address) {

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -9,4 +9,5 @@ public class TypicalIndexes {
     public static final Index INDEX_FIRST_PERSON = Index.fromOneBased(1);
     public static final Index INDEX_SECOND_PERSON = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_PERSON = Index.fromOneBased(3);
+    public static final Index INDEX_FOURTH_PERSON = Index.fromOneBased(4);
 }


### PR DESCRIPTION
The existing tagging system only allows user to overwrite the tags of a
specified contact, via the edit command.

This commit will allow users to add tags to a specified contact, one at
a time, instead of overwriting all the tags.

Let's,
* Add an alternate path in parseCommand to return AddTagCommand
* Add AddTagCommand for add tag command execution
* Add AddTagCommandParser to parse user input to create AddTagCommand

The implementation mainly uses the existing abstraction.

Test cases are added to ensure that the application has no regression
after the previous commit that resolve #36.

Let's,
* Add test method parseCommand_addTag to AddressBookParserTest
* Add AddTagCommandParserTest
  * Add parse_noTag_failure()
  * Add parse_invalidTag_failure()
  * Add parse_noIndex_failure()
  * Add parse_invalidIndex_failure()
  * Add parse_additionalPrefix_failure()
  * Add parse_allFieldsSpecified_success()
  * Add parse_multipleTag_acceptsLast()
* Add AddTagCommandTest
  * Add constructor_anyFieldsNull_throwsNullPointerException()
  * Add execute_validIndexUnfilteredList_success()
  * Add execute_duplicatedTagUnfilteredList_throwsCommandException()
  * Add execute_invalidIndexUnfilteredList_throwsCommandException()
  * Add execute_validIndexFilteredList_success()
  * Add execute_duplicatedTagFilteredList_throwsCommandException()
  * Add execute_invalidIndexFilteredList_throwsCommandException()
  * Add equals()
* Add addTags to PersonBuilder to allow adding of tags, not overwriting
* Add INDEX_FOURTH_PERSON to TypicalIndexes