### PR TITLE
Add command to delete a tag from contact

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTagCommand.java
@@ -90,6 +90,10 @@ public class AddTagCommand extends Command {
     /**
      * Creates and returns a {@code Person} with the details of personToEdit {@code Person}
      * added with tagToAdd {@code Tag}.
+     *
+     * @param personToEdit the {@code Person} to add the {@code Tag} to.
+     * @param tagToAdd the {@code Tag} to add to {@code Person}.
+     * @return the edited {@code Person} added with tagToAdd {@code Tag}.
      */
     private static Person createPersonWithAddedTag(Person personToEdit, Tag tagToAdd) {
         assert personToEdit != null;

--- a/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
@@ -90,6 +90,10 @@ public class DeleteTagCommand extends Command {
     /**
      * Creates and returns a {@code Person} with the details of personToEdit {@code Person}
      * with tagToDelete {@code Tag} deleted.
+     *
+     * @param personToEdit the {@code Person} to delete the {@code Tag} from.
+     * @param tagToDelete the {@code Tag} to delete from {@code Person}.
+     * @return the edited {@code Person} with tagToDelete {@code Tag} deleted.
      */
     private static Person createPersonWithDeletedTag(Person personToEdit, Tag tagToDelete) {
         assert personToEdit != null;

--- a/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
@@ -1,0 +1,140 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.date.BirthDate;
+import seedu.address.model.date.RecentDate;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Description;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Deletes a tag from an existing person in the address book, if the tag exists.
+ */
+public class DeleteTagCommand extends Command {
+
+    public static final String COMMAND_WORD = "untag";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes a tag from the tags of an existing contact, "
+            + "as specified by the index number used in the displayed person list. The tag will be deleted only if "
+            + "the tag is valid and is tagged to the contact (case-insensitive).\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + "[" + PREFIX_TAG + "TAG]\n"
+            + "Example: " + COMMAND_WORD + " 2 "
+            + PREFIX_TAG + "friends";
+
+    public static final String MESSAGE_DELETE_TAG_SUCCESS = "Deleted tag: %1$s";
+    public static final String MESSAGE_MISSING_TAG = "This person is not tagged to %1$s.";
+
+    private final Index index;
+    private final Tag tag;
+
+    /**
+     * Constructs an {@code DeleteTagCommand} with the given {@code Index} and {@code Tag}.
+     *
+     * @param index of the person in the filtered person list to add the {@code Tag}.
+     * @param tag to be deleted from the {@code Person} specified by {@code index}.
+     */
+    public DeleteTagCommand(Index index, Tag tag) {
+        requireNonNull(index);
+        requireNonNull(tag);
+
+        this.index = index;
+        this.tag = tag;
+    }
+
+    /**
+     * Deletes a tag from an existing person in the address book, if the tag exists.
+     *
+     * @param model {@code Model} which the command should operate on.
+     * @return the command result after the command execution.
+     * @throws CommandException if the {@code Tag} do not exist or the {@code Index} is invalid.
+     */
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToEdit = lastShownList.get(index.getZeroBased());
+
+        if (!personToEdit.hasTag(this.tag)) {
+            throw new CommandException(String.format(MESSAGE_MISSING_TAG, this.tag));
+        }
+
+        Person editedPerson = createPersonWithDeletedTag(personToEdit, this.tag);
+
+        model.setPerson(personToEdit, editedPerson);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+
+        return new CommandResult(String.format(MESSAGE_DELETE_TAG_SUCCESS, editedPerson));
+    }
+
+    /**
+     * Creates and returns a {@code Person} with the details of personToEdit {@code Person}
+     * with tagToDelete {@code Tag} deleted.
+     */
+    private static Person createPersonWithDeletedTag(Person personToEdit, Tag tagToDelete) {
+        assert personToEdit != null;
+
+        Name updatedName = personToEdit.getName();
+        Phone updatedPhone = personToEdit.getPhone();
+        Email updatedEmail = personToEdit.getEmail();
+        Address updatedAddress = personToEdit.getAddress();
+        BirthDate updatedBirthDate = personToEdit.getBirthDate();
+        RecentDate updatedRecentDate = personToEdit.getContactedDate();
+        Description updatedDescription = personToEdit.getContactedDesc();
+        Set<Tag> updatedTags = deleteTagFromSet(personToEdit.getTags(), tagToDelete);
+
+        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedBirthDate,
+                updatedRecentDate, updatedDescription, updatedTags);
+    }
+
+    /**
+     * Deletes a {Tag} from a tag set by creating a new {@code HashSet} (immutable) if the tag exists.
+     *
+     * @param tags the tag set to delete a {@code Tag} from.
+     * @param tagToDelete the {@code Tag} to be deleted.
+     * @return an immutable tag set consisting of the existing {@code Tag} and {@code tagToDelete} (only unique tags).
+     */
+    private static Set<Tag> deleteTagFromSet(Set<Tag> tags, Tag tagToDelete) {
+        Set<Tag> updatedTags = new HashSet<>(tags);
+        updatedTags.remove(tagToDelete);
+        return Collections.unmodifiableSet(updatedTags);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof DeleteTagCommand)) {
+            return false;
+        }
+
+        // state check
+        DeleteTagCommand e = (DeleteTagCommand) other;
+        return this.index.equals(e.index)
+                && this.tag.equals(e.tag);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -12,6 +12,7 @@ import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.ContactedCommand;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteTagCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
@@ -76,6 +77,9 @@ public class AddressBookParser {
 
         case AddTagCommand.COMMAND_WORD:
             return new AddTagCommandParser().parse(arguments);
+
+        case DeleteTagCommand.COMMAND_WORD:
+            return new DeleteTagCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/logic/parser/DeleteTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteTagCommandParser.java
@@ -5,24 +5,24 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.AddTagCommand;
+import seedu.address.logic.commands.DeleteTagCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.Tag;
 
 /**
- * Parses input arguments and creates a new {@code AddTagCommand} object.
+ * Parses input arguments and creates a new {@code DeleteTagCommand} object.
  */
-public class AddTagCommandParser implements Parser<AddTagCommand> {
+public class DeleteTagCommandParser implements Parser<DeleteTagCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the {@code AddTagCommand}
-     * and returns an {@code AddTagCommand} object for execution.
+     * Parses the given {@code String} of arguments in the context of the {@code DeleteTagCommand}
+     * and returns an {@code DeleteTagCommand} object for execution.
      *
      * @param args the {@code String} of arguments to be parsed.
-     * @returns the created {@code AddTagCommand} object.
+     * @returns the created {@code DeleteTagCommand} object.
      * @throws ParseException if the user input does not conform the expected format.
      */
-    public AddTagCommand parse(String args) throws ParseException {
+    public DeleteTagCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argumentMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TAG);
 
@@ -31,15 +31,15 @@ public class AddTagCommandParser implements Parser<AddTagCommand> {
         try {
             index = ParserUtil.parseIndex(argumentMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddTagCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteTagCommand.MESSAGE_USAGE), pe);
         }
 
         if (argumentMultimap.getValue(PREFIX_TAG).isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddTagCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteTagCommand.MESSAGE_USAGE));
         }
 
         Tag tag = ParserUtil.parseTag(argumentMultimap.getValue(PREFIX_TAG).get());
 
-        return new AddTagCommand(index, tag);
+        return new DeleteTagCommand(index, tag);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteTagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteTagCommandTest.java
@@ -1,0 +1,166 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.logic.commands.DeleteTagCommand.MESSAGE_MISSING_TAG;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.model.tag.Tag;
+import seedu.address.testutil.PersonBuilder;
+
+public class DeleteTagCommandTest {
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void constructor_anyFieldsNull_throwsNullPointerException() {
+        Tag tag = new Tag("foo");
+        assertThrows(NullPointerException.class, () -> new DeleteTagCommand(null, tag));
+        assertThrows(NullPointerException.class, () -> new DeleteTagCommand(INDEX_FIRST_PERSON, null));
+        assertThrows(NullPointerException.class, () -> new DeleteTagCommand(null, null));
+    }
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Tag tag = new Tag("friends");
+
+        Person personToDeleteTag = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+
+        assert personToDeleteTag.hasTag(tag);
+
+        Person expectedPerson = new PersonBuilder(personToDeleteTag).deleteTags("friends").build();
+
+        DeleteTagCommand deleteTagCommand = new DeleteTagCommand(INDEX_FIRST_PERSON, tag);
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.setPerson(model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()),
+                expectedPerson);
+
+        String expectedMessage = String.format(DeleteTagCommand.MESSAGE_DELETE_TAG_SUCCESS, expectedPerson);
+
+        assertCommandSuccess(deleteTagCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_missingTagUnfilteredList_throwsCommandException() {
+        // same tag
+        Tag tag = new Tag("randomTag");
+        Person personToDeleteTag = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+
+        // Alice must not have the tag "randomTag"
+        assertFalse(personToDeleteTag.hasTag(tag));
+
+        DeleteTagCommand deleteTagCommand = new DeleteTagCommand(INDEX_FIRST_PERSON, tag);
+        String expectedMessage = String.format(MESSAGE_MISSING_TAG, tag);
+        assertCommandFailure(deleteTagCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getAddressBook().getPersonList().size() + 10);
+
+        // ensures that outOfBoundIndex is out bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() >= model.getAddressBook().getPersonList().size());
+
+        DeleteTagCommand deleteTagCommand = new DeleteTagCommand(outOfBoundIndex, new Tag("randomTag"));
+
+        assertCommandFailure(deleteTagCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        Tag tag = new Tag("friends");
+
+        Person personToDeleteTag = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person expectedPerson = new PersonBuilder(personToDeleteTag).deleteTags("friends").build();
+
+        DeleteTagCommand deleteTagCommand = new DeleteTagCommand(INDEX_FIRST_PERSON, tag);
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.setPerson(model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()),
+                expectedPerson);
+
+        String expectedMessage = String.format(DeleteTagCommand.MESSAGE_DELETE_TAG_SUCCESS, expectedPerson);
+
+        assertCommandSuccess(deleteTagCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_missingTagFilteredList_throwsCommandException() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        // same tag
+        Tag tag = new Tag("randomTag");
+        Person personToDeleteTag = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+
+        // Alice must not have the tag "randomTag"
+        assertFalse(personToDeleteTag.hasTag(tag));
+
+        DeleteTagCommand deleteTagCommand = new DeleteTagCommand(INDEX_FIRST_PERSON, tag);
+        String expectedMessage = String.format(MESSAGE_MISSING_TAG, tag);
+        assertCommandFailure(deleteTagCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+
+        DeleteTagCommand deleteTagCommand = new DeleteTagCommand(outOfBoundIndex, new Tag("randomTag"));
+
+        assertCommandFailure(deleteTagCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        Index firstIndex = Index.fromOneBased(1);
+        Index secondIndex = Index.fromOneBased(2);
+
+        Tag firstTag = new Tag("first");
+        Tag secondTag = new Tag("second");
+
+        DeleteTagCommand deleteTagFirstCommand = new DeleteTagCommand(firstIndex, firstTag);
+        DeleteTagCommand deleteTagSecondCommand = new DeleteTagCommand(secondIndex, firstTag);
+        DeleteTagCommand deleteTagThirdCommand = new DeleteTagCommand(firstIndex, secondTag);
+        DeleteTagCommand deleteTagFourthCommand = new DeleteTagCommand(secondIndex, secondTag);
+
+        // same object -> returns true
+        assertTrue(deleteTagFirstCommand.equals(deleteTagFirstCommand));
+
+        // same values -> returns true
+        DeleteTagCommand deleteTagFirstCommandCopy = new DeleteTagCommand(firstIndex, firstTag);
+        assertTrue(deleteTagFirstCommand.equals(deleteTagFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(deleteTagFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(deleteTagFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(deleteTagFirstCommand.equals(deleteTagSecondCommand));
+        assertFalse(deleteTagFirstCommand.equals(deleteTagThirdCommand));
+        assertFalse(deleteTagFirstCommand.equals(deleteTagFourthCommand));
+        assertFalse(deleteTagSecondCommand.equals(deleteTagThirdCommand));
+        assertFalse(deleteTagSecondCommand.equals(deleteTagFourthCommand));
+        assertFalse(deleteTagThirdCommand.equals(deleteTagFourthCommand));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -23,6 +23,7 @@ import seedu.address.logic.commands.AddTagCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.ContactedCommand;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteTagCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.ExitCommand;
@@ -101,6 +102,14 @@ public class AddressBookParserTest {
         AddTagCommand command = (AddTagCommand) parser.parseCommand(AddTagCommand.COMMAND_WORD + " "
                 + INDEX_FIRST_PERSON.getOneBased() + " " + PREFIX_TAG + VALID_TAG_FRIEND);
         assertEquals(new AddTagCommand(INDEX_FIRST_PERSON, tag), command);
+    }
+
+    @Test
+    public void parseCommand_deleteTag() throws Exception {
+        Tag tag = new Tag(VALID_TAG_FRIEND);
+        DeleteTagCommand command = (DeleteTagCommand) parser.parseCommand(DeleteTagCommand.COMMAND_WORD + " "
+                + INDEX_FIRST_PERSON.getOneBased() + " " + PREFIX_TAG + VALID_TAG_FRIEND);
+        assertEquals(new DeleteTagCommand(INDEX_FIRST_PERSON, tag), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteTagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteTagCommandParserTest.java
@@ -1,0 +1,108 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
+import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.DeleteTagCommand;
+import seedu.address.model.tag.Tag;
+
+public class DeleteTagCommandParserTest {
+
+    private static final String TAG_EMPTY = " " + PREFIX_TAG;
+
+    private static final String MESSAGE_INVALID_FORMAT =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteTagCommand.MESSAGE_USAGE);
+
+    private final DeleteTagCommandParser parser = new DeleteTagCommandParser();
+
+    @Test
+    public void parse_noTag_failure() {
+        assertParseFailure(parser, "1", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidTag_failure() {
+        assertParseFailure(parser, "1" + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, INDEX_FIRST_PERSON.getOneBased() + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + TAG_EMPTY + "hubby and me", Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + TAG_EMPTY + "hubby and me" + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_noIndex_failure() {
+        assertParseFailure(parser, PREAMBLE_WHITESPACE + TAG_DESC_FRIEND, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, TAG_EMPTY, MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidIndex_failure() {
+        assertParseFailure(parser, PREAMBLE_NON_EMPTY + TAG_DESC_FRIEND, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "string" + TAG_DESC_FRIEND, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "*(" + TAG_DESC_FRIEND, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "*(12sz" + TAG_DESC_FRIEND, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "0" + TAG_DESC_FRIEND, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "-1" + TAG_DESC_FRIEND, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1 1" + TAG_DESC_FRIEND, MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_additionalPrefix_failure() {
+        assertParseFailure(parser, PREFIX_ADDRESS + "address " + INDEX_FIRST_PERSON.getOneBased()
+                + TAG_DESC_FRIEND, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, INDEX_FIRST_PERSON.getOneBased() + TAG_DESC_FRIEND
+                + EMAIL_DESC_AMY, Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, INDEX_FIRST_PERSON.getOneBased() + " " + PREFIX_PHONE + "phone"
+                + TAG_DESC_FRIEND, MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_allFieldsSpecified_success() {
+        // vanilla
+        DeleteTagCommand expectedCommand = new DeleteTagCommand(INDEX_FIRST_PERSON, new Tag(VALID_TAG_FRIEND));
+        assertParseSuccess(parser, INDEX_FIRST_PERSON.getOneBased() + TAG_EMPTY + VALID_TAG_FRIEND, expectedCommand);
+
+        // trailing and leading whitespaces
+        expectedCommand = new DeleteTagCommand(INDEX_FIRST_PERSON, new Tag(VALID_TAG_FRIEND));
+        assertParseSuccess(parser, " \n \t  " + INDEX_FIRST_PERSON.getOneBased() + TAG_EMPTY
+                + VALID_TAG_FRIEND + " \n \t  ", expectedCommand);
+
+        // leading spaces in tag
+        expectedCommand = new DeleteTagCommand(INDEX_FIRST_PERSON, new Tag(VALID_TAG_FRIEND));
+        assertParseSuccess(parser, "  \n \t " + INDEX_FIRST_PERSON.getOneBased() + TAG_EMPTY + " \n \t  "
+                + VALID_TAG_FRIEND + " \n \t  ", expectedCommand);
+    }
+
+    @Test
+    public void parse_multipleTag_acceptsLast() {
+        // two different tags
+        DeleteTagCommand expectedCommand = new DeleteTagCommand(INDEX_FIRST_PERSON, new Tag(VALID_TAG_FRIEND));
+        assertParseSuccess(parser, INDEX_FIRST_PERSON.getOneBased() + TAG_DESC_HUSBAND
+                + TAG_DESC_FRIEND, expectedCommand);
+
+        // two same tags
+        expectedCommand = new DeleteTagCommand(INDEX_FIRST_PERSON, new Tag(VALID_TAG_FRIEND));
+        assertParseSuccess(parser, INDEX_FIRST_PERSON.getOneBased() + TAG_DESC_FRIEND
+                + TAG_DESC_FRIEND, expectedCommand);
+
+        // three tags
+        expectedCommand = new DeleteTagCommand(INDEX_FIRST_PERSON, new Tag(VALID_TAG_HUSBAND));
+        assertParseSuccess(parser, INDEX_FIRST_PERSON.getOneBased() + TAG_DESC_FRIEND
+                + TAG_DESC_FRIEND + TAG_DESC_HUSBAND, expectedCommand);
+    }
+}

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -95,6 +95,20 @@ public class PersonBuilder {
     }
 
     /**
+     * Parses the {@code tags} into a {@code Set<Tag>} and deletes them from the tag set of {@code Person}
+     * that we are building.
+     *
+     * @param tags the tags to delete from the tag set.
+     * @return this {@code PersonBuilder}.
+     */
+    public PersonBuilder deleteTags(String ... tags) {
+        Set<Tag> newSet = new HashSet<>(this.tags);
+        newSet.removeAll(SampleDataUtil.getTagSet(tags));
+        this.tags = newSet;
+        return this;
+    }
+
+    /**
      * Sets the {@code Address} of the {@code Person} that we are building.
      */
     public PersonBuilder withAddress(String address) {


### PR DESCRIPTION
The existing tagging system only allows user to clear all the tags of a
specified contact, via the edit command.

This commit will allow users to delete tags from a specified contact,
one at a time, instead of clearing all the tags.

Let's,
* Add an alternate path in parseCommand to return DeleteTagCommand
* Add DeleteTagCommand for delete tag command execution
* Add DeleteTagCommandParser to parse user input to DeleteTagCommand
* Fix AddCommand to AddTagCommand in AddTagCommandParser JavaDoc

The implementation mainly uses the existing abstraction.

Test cases are added to ensure that the application has no regression
after the previous commit that resolve https://github.com/AY2122S2-CS2103T-T17-3/tp/issues/35.

Let's,
* Add test method parseCommand_deleteTag to AddressBookParserTest
* Add DeleteTagCommandParserTest
  * Add parse_noTag_failure()
  * Add parse_invalidTag_failure()
  * Add parse_noIndex_failure()
  * Add parse_invalidIndex_failure()
  * Add parse_additionalPrefix_failure()
  * Add parse_allFieldsSpecified_success()
  * Add parse_multipleTag_acceptsLast()
* Add DeleteTagCommandTest
  * Add constructor_anyFieldsNull_throwsNullPointerException()
  * Add execute_validIndexUnfilteredList_success()
  * Add execute_missingTagUnfilteredList_throwsCommandException()
  * Add execute_invalidIndexUnfilteredList_throwsCommandException()
  * Add execute_validIndexFilteredList_success()
  * Add execute_missingTagFilteredList_throwsCommandException()
  * Add execute_invalidIndexFilteredList_throwsCommandException()
  * Add equals()
* Add deleteTags to PersonBuilder to allow deleting of tags