### PR TITLE
Add Birthday Command

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -6,8 +6,10 @@ package seedu.address.commons.core;
 public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
+    public static final String MESSAGE_INVALID_ARGUMENTS = "Arguments are not allowed after this command word!";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+
 
 }

--- a/src/main/java/seedu/address/logic/commands/BirthdayCommand.java
+++ b/src/main/java/seedu/address/logic/commands/BirthdayCommand.java
@@ -9,7 +9,7 @@ import seedu.address.model.Model;
 
 public class BirthdayCommand extends Command {
 
-    public static final String COMMAND_WORD = "Birthdays";
+    public static final String COMMAND_WORD = "birthdays";
 
     public static final String MESSAGE_SUCCESS = "Here are the people with birthdays today.\n"
                                                     + Messages.MESSAGE_PERSONS_LISTED_OVERVIEW

--- a/src/main/java/seedu/address/logic/commands/BirthdayCommand.java
+++ b/src/main/java/seedu/address/logic/commands/BirthdayCommand.java
@@ -1,0 +1,31 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS_WITH_BIRTHDAY_TODAY;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+
+public class BirthdayCommand extends Command {
+
+    public static final String COMMAND_WORD = "Birthdays";
+
+    public static final String MESSAGE_SUCCESS = "Here are the people with birthdays today.\n"
+                                                    + Messages.MESSAGE_PERSONS_LISTED_OVERVIEW
+                                                    + "\nSend them a birthday message!";
+    /**
+     * Executes the command and returns the result message.
+     *
+     * @param model {@code Model} which the command should operate on.
+     * @return feedback message of the operation result for display
+     * @throws CommandException If an error occurs during command execution.
+     */
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS_WITH_BIRTHDAY_TODAY);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, model.getFilteredPersonListSize()));
+    }
+
+}

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -30,7 +30,7 @@ public class FindCommand extends Command {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
         return new CommandResult(
-                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonListSize()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/HashtagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HashtagCommand.java
@@ -50,7 +50,7 @@ public class HashtagCommand extends Command {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
         return new CommandResult(
-                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonListSize()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_ARGUMENTS;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
@@ -65,15 +66,18 @@ public class AddressBookParser {
             return new DeleteCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
+            isValidCommand(arguments);
             return new ClearCommand();
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);
 
         case BirthdayCommand.COMMAND_WORD:
+            isValidCommand(arguments);
             return new BirthdayCommand();
 
         case ListCommand.COMMAND_WORD:
+            isValidCommand(arguments);
             return new ListCommand();
 
         case ContactedCommand.COMMAND_WORD:
@@ -86,14 +90,23 @@ public class AddressBookParser {
             return new DeleteTagCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
+            isValidCommand(arguments);
             return new ExitCommand();
 
         case HelpCommand.COMMAND_WORD:
+            isValidCommand(arguments);
             return new HelpCommand();
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }
+    }
+
+    private void isValidCommand(String args) throws ParseException {
+        if (args.length() != 0) {
+            throw new ParseException(MESSAGE_INVALID_ARGUMENTS);
+        }
+
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -8,6 +8,7 @@ import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddTagCommand;
+import seedu.address.logic.commands.BirthdayCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.ContactedCommand;
@@ -68,6 +69,9 @@ public class AddressBookParser {
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);
+
+        case BirthdayCommand.COMMAND_WORD:
+            return new BirthdayCommand();
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -13,6 +13,7 @@ import seedu.address.model.person.Person;
 public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
+    Predicate<Person> PREDICATE_SHOW_ALL_PERSONS_WITH_BIRTHDAY_TODAY = person -> person.isBirthdayToday();
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.
@@ -78,6 +79,11 @@ public interface Model {
 
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();
+
+    /**
+     * Returns the number of persons with the filtered predicate.
+     */
+    int getFilteredPersonListSize();
 
     /**
      * Updates the filter of the filtered person list to filter by the given {@code predicate}.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -123,6 +123,11 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public int getFilteredPersonListSize() {
+        return filteredPersons.size();
+    }
+
+    @Override
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -74,6 +74,10 @@ public class Person {
         return birthDate;
     }
 
+    public boolean isBirthdayToday() {
+        return this.birthDate.isToday();
+    }
+
     /**
      * Returns an immutable tag set, which throws {@code UnsupportedOperationException}
      * if modification is attempted.

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -144,6 +144,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public int getFilteredPersonListSize() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void updateFilteredPersonList(Predicate<Person> predicate) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/BirthdayCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/BirthdayCommandTest.java
@@ -55,6 +55,7 @@ class BirthdayCommandTest {
 
     @Test
     public void execute_listHasNoPersons_showsEmptyList() {
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS_WITH_BIRTHDAY_TODAY);
         assertCommandSuccess(new BirthdayCommand(), model, MESSAGE_SUCCESS, emptyModel);
     }
 

--- a/src/test/java/seedu/address/logic/commands/BirthdayCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/BirthdayCommandTest.java
@@ -1,8 +1,6 @@
 package seedu.address.logic.commands;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS_WITH_BIRTHDAY_TODAY;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BOB;
@@ -26,9 +24,9 @@ import seedu.address.testutil.PersonBuilder;
 class BirthdayCommandTest {
 
     private static final DateTimeFormatter FORMATTER_INPUT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-    private static final String MESSAGE_SUCCESS = String.format(BirthdayCommand.MESSAGE_SUCCESS, 0);
     private Model model;
     private Model emptyModel;
+    private Model expectedModel;
     private Person alice;
     private Person bob;
     private Person carl;
@@ -37,6 +35,7 @@ class BirthdayCommandTest {
     @BeforeEach
     public void setUp() {
         model = new ModelManager(new AddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         emptyModel = new ModelManager(new AddressBook(), new UserPrefs());
         alice = ALICE;
         bob = BOB;
@@ -56,36 +55,51 @@ class BirthdayCommandTest {
     @Test
     public void execute_listHasNoPersons_showsEmptyList() {
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS_WITH_BIRTHDAY_TODAY);
-        assertCommandSuccess(new BirthdayCommand(), model, MESSAGE_SUCCESS, emptyModel);
+
+        assertCommandSuccess(new BirthdayCommand(),
+                model,
+                String.format(BirthdayCommand.MESSAGE_SUCCESS, 0),
+                emptyModel);
     }
 
     @Test
     public void execute_listHasNoBirthdaysToday_showsEmptyList() {
         model.addPerson(bob);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS_WITH_BIRTHDAY_TODAY);
-        assertEquals(0, model.getFilteredPersonListSize());
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        assertEquals(1, model.getFilteredPersonListSize());
+        expectedModel.addPerson(bob);
+        expectedModel.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS_WITH_BIRTHDAY_TODAY);
+        int size = expectedModel.getFilteredPersonListSize();
+        assertCommandSuccess(new BirthdayCommand(),
+                model,
+                String.format(BirthdayCommand.MESSAGE_SUCCESS, size),
+                expectedModel);
     }
 
     @Test
     public void execute_listHasBirthdayToday_showsOne() {
         model.addPerson(alice);
+        expectedModel.addPerson(alice);
         model.addPerson(bob);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS_WITH_BIRTHDAY_TODAY);
-        assertEquals(1, model.getFilteredPersonListSize());
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        assertEquals(2, model.getFilteredPersonListSize());
+        expectedModel.addPerson(bob);
+        expectedModel.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS_WITH_BIRTHDAY_TODAY);
+        int size = expectedModel.getFilteredPersonListSize();
+        assertCommandSuccess(new BirthdayCommand(),
+                model,
+                String.format(BirthdayCommand.MESSAGE_SUCCESS, size),
+                expectedModel);
     }
 
     @Test
     public void execute_listHasBirthDateTenYearsAgo_showsOne() {
         model.addPerson(carl);
+        expectedModel.addPerson(carl);
         model.addPerson(bob);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS_WITH_BIRTHDAY_TODAY);
-        assertEquals(1, model.getFilteredPersonListSize());
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        assertEquals(2, model.getFilteredPersonListSize());
+        expectedModel.addPerson(bob);
+        expectedModel.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS_WITH_BIRTHDAY_TODAY);
+        int size = expectedModel.getFilteredPersonListSize();
+        assertCommandSuccess(new BirthdayCommand(),
+                model,
+                String.format(BirthdayCommand.MESSAGE_SUCCESS, size),
+                expectedModel);
     }
 
 

--- a/src/test/java/seedu/address/logic/commands/BirthdayCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/BirthdayCommandTest.java
@@ -1,0 +1,91 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS_WITH_BIRTHDAY_TODAY;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BOB;
+import static seedu.address.testutil.TypicalPersons.CARL;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.PersonBuilder;
+
+
+
+class BirthdayCommandTest {
+
+    private static final DateTimeFormatter FORMATTER_INPUT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    private static final String MESSAGE_SUCCESS = String.format(BirthdayCommand.MESSAGE_SUCCESS, 0);
+    private Model model;
+    private Model emptyModel;
+    private Person alice;
+    private Person bob;
+    private Person carl;
+
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(new AddressBook(), new UserPrefs());
+        emptyModel = new ModelManager(new AddressBook(), new UserPrefs());
+        alice = ALICE;
+        bob = BOB;
+        carl = CARL;
+        LocalDate today = LocalDate.now();
+        String todayDate = today.format(FORMATTER_INPUT);
+        LocalDate yesterday = today.minusDays(1);
+        String yesterdayDate = yesterday.format(FORMATTER_INPUT);
+        LocalDate tenYearsAgo = today.minusYears(10);
+        String tenYearsAgoDate = tenYearsAgo.format(FORMATTER_INPUT);
+        alice = new PersonBuilder(alice).withBirthDate(todayDate).build();
+        bob = new PersonBuilder(bob).withBirthDate(yesterdayDate).build();
+        carl = new PersonBuilder(carl).withBirthDate(tenYearsAgoDate).build();
+
+    }
+
+    @Test
+    public void execute_listHasNoPersons_showsEmptyList() {
+        assertCommandSuccess(new BirthdayCommand(), model, MESSAGE_SUCCESS, emptyModel);
+    }
+
+    @Test
+    public void execute_listHasNoBirthdaysToday_showsEmptyList() {
+        model.addPerson(bob);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS_WITH_BIRTHDAY_TODAY);
+        assertEquals(0, model.getFilteredPersonListSize());
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        assertEquals(1, model.getFilteredPersonListSize());
+    }
+
+    @Test
+    public void execute_listHasBirthdayToday_showsOne() {
+        model.addPerson(alice);
+        model.addPerson(bob);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS_WITH_BIRTHDAY_TODAY);
+        assertEquals(1, model.getFilteredPersonListSize());
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        assertEquals(2, model.getFilteredPersonListSize());
+    }
+
+    @Test
+    public void execute_listHasBirthDateTenYearsAgo_showsOne() {
+        model.addPerson(carl);
+        model.addPerson(bob);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS_WITH_BIRTHDAY_TODAY);
+        assertEquals(1, model.getFilteredPersonListSize());
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        assertEquals(2, model.getFilteredPersonListSize());
+    }
+
+
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_ARGUMENTS;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddTagCommand;
+import seedu.address.logic.commands.BirthdayCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.ContactedCommand;
 import seedu.address.logic.commands.DeleteCommand;
@@ -56,7 +58,8 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_clear() throws Exception {
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
+        assertThrows(ParseException.class, MESSAGE_INVALID_ARGUMENTS, ()
+            -> parser.parseCommand(ExitCommand.COMMAND_WORD + " 3"));
     }
 
     @Test
@@ -78,7 +81,8 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_exit() throws Exception {
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD) instanceof ExitCommand);
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3") instanceof ExitCommand);
+        assertThrows(ParseException.class, MESSAGE_INVALID_ARGUMENTS, ()
+            -> parser.parseCommand(ExitCommand.COMMAND_WORD + " 3"));
     }
 
     @Test
@@ -115,13 +119,22 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_help() throws Exception {
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
+        assertThrows(ParseException.class, MESSAGE_INVALID_ARGUMENTS, ()
+            -> parser.parseCommand(HelpCommand.COMMAND_WORD + " 3"));
     }
 
     @Test
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+        assertThrows(ParseException.class, MESSAGE_INVALID_ARGUMENTS, ()
+            -> parser.parseCommand(ListCommand.COMMAND_WORD + " 3"));
+    }
+
+    @Test
+    public void parseCommand_birthday() throws Exception {
+        assertTrue(parser.parseCommand(BirthdayCommand.COMMAND_WORD) instanceof BirthdayCommand);
+        assertThrows(ParseException.class, MESSAGE_INVALID_ARGUMENTS, ()
+            -> parser.parseCommand(BirthdayCommand.COMMAND_WORD + " 3"));
     }
 
     @Test
@@ -143,6 +156,7 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_unknownCommand_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, ()
+            -> parser.parseCommand("unknownCommand"));
     }
 }


### PR DESCRIPTION
The application does not allow users to look for persons with
birthdays today easily. This prevents them from having a
snapshot of who to send well wishes to.

Let's do the following to close AY2122S2-CS2103T-T17-3#58 and close AY2122S2-CS2103T-T17-3#60:
- Add a predicate to use for filtering for birthdays
- Add a designated command for applying the predicate filter
- Write tests for edge cases for better code and path coverage