### PR TITLE
Add backup function

### DIFF
--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -13,6 +13,7 @@ import seedu.address.commons.core.GuiSettings;
  */
 public class UserPrefs implements ReadOnlyUserPrefs {
 
+    private static Path backupAddressBookFilePath = Paths.get("data", "backup.json");
     private GuiSettings guiSettings = new GuiSettings();
     private Path addressBookFilePath = Paths.get("data" , "addressbook.json");
 
@@ -49,6 +50,10 @@ public class UserPrefs implements ReadOnlyUserPrefs {
 
     public Path getAddressBookFilePath() {
         return addressBookFilePath;
+    }
+
+    public static Path getBackupFilePath() {
+        return backupAddressBookFilePath;
     }
 
     public void setAddressBookFilePath(Path addressBookFilePath) {

--- a/src/main/java/seedu/address/storage/JsonAddressBookStorage.java
+++ b/src/main/java/seedu/address/storage/JsonAddressBookStorage.java
@@ -61,7 +61,7 @@ public class JsonAddressBookStorage implements AddressBookStorage {
         } catch (IllegalValueException ive) {
             logger.info("Illegal values found in " + filePath + ": " + ive.getMessage());
             try {
-                emergencyBackupFiles();
+                backupFiles();
             } catch (IOException ioe) {
                 logger.info(FILE_OPS_ERROR_MESSAGE + BACKUP_PATH);
             }
@@ -74,7 +74,7 @@ public class JsonAddressBookStorage implements AddressBookStorage {
      *
      * @throws IOException if the designated file paths are invalid.
      */
-    public void emergencyBackupFiles() throws IOException {
+    public void backupFiles() throws IOException {
         Files.copy(getAddressBookFilePath(), BACKUP_PATH);
     }
 
@@ -82,7 +82,6 @@ public class JsonAddressBookStorage implements AddressBookStorage {
     public void saveAddressBook(ReadOnlyAddressBook addressBook) throws IOException {
         saveAddressBook(addressBook, filePath);
     }
-
 
     /**
      * Similar to {@link #saveAddressBook(ReadOnlyAddressBook)}.

--- a/src/main/java/seedu/address/storage/JsonAddressBookStorage.java
+++ b/src/main/java/seedu/address/storage/JsonAddressBookStorage.java
@@ -1,8 +1,10 @@
 package seedu.address.storage;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.LogicManager.FILE_OPS_ERROR_MESSAGE;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.logging.Logger;
@@ -13,6 +15,7 @@ import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.FileUtil;
 import seedu.address.commons.util.JsonUtil;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.UserPrefs;
 
 /**
  * A class to access AddressBook data stored as a json file on the hard disk.
@@ -20,6 +23,8 @@ import seedu.address.model.ReadOnlyAddressBook;
 public class JsonAddressBookStorage implements AddressBookStorage {
 
     private static final Logger logger = LogsCenter.getLogger(JsonAddressBookStorage.class);
+
+    private static final Path BACKUP_PATH = UserPrefs.getBackupFilePath();
 
     private Path filePath;
 
@@ -55,14 +60,29 @@ public class JsonAddressBookStorage implements AddressBookStorage {
             return Optional.of(jsonAddressBook.get().toModelType());
         } catch (IllegalValueException ive) {
             logger.info("Illegal values found in " + filePath + ": " + ive.getMessage());
+            try {
+                emergencyBackupFiles();
+            } catch (IOException ioe) {
+                logger.info(FILE_OPS_ERROR_MESSAGE + BACKUP_PATH);
+            }
             throw new DataConversionException(ive);
         }
+    }
+
+    /**
+     * Creates an exact copy of the current addressbook.json file.
+     *
+     * @throws IOException if the designated file paths are invalid.
+     */
+    public void emergencyBackupFiles() throws IOException {
+        Files.copy(getAddressBookFilePath(), BACKUP_PATH);
     }
 
     @Override
     public void saveAddressBook(ReadOnlyAddressBook addressBook) throws IOException {
         saveAddressBook(addressBook, filePath);
     }
+
 
     /**
      * Similar to {@link #saveAddressBook(ReadOnlyAddressBook)}.


### PR DESCRIPTION
The application will discard existing save file when an error
occurs during reading. This is detrimental because the user will
lose all data if they made a small error during a manual edit of
the save file.

Let's create a backup of the save file upon receipt of an Illegal
Value Exception in the readAddressBook method.

This will close AY2122S2-CS2103T-T17-3#64.