### PR TITLE
Fix contact card display

### DIFF
--- a/src/main/java/seedu/address/model/date/DocumentedDate.java
+++ b/src/main/java/seedu/address/model/date/DocumentedDate.java
@@ -4,6 +4,7 @@ import static java.time.temporal.ChronoUnit.DAYS;
 import static java.util.Objects.requireNonNull;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 
 /**
@@ -11,6 +12,7 @@ import java.time.format.DateTimeParseException;
  */
 public class DocumentedDate {
     public static final String MESSAGE_CONSTRAINTS = "Dates should be in the format of YYYY-MM-DD";
+    private static final DateTimeFormatter FORMATTER_OUTPUT = DateTimeFormatter.ofPattern("dd MMM yyyy");
     private LocalDate date;
 
     /**
@@ -78,10 +80,7 @@ public class DocumentedDate {
      */
     @Override
     public String toString() {
-        return String.format("%d %s %d",
-                date.getDayOfMonth(),
-                date.getMonth(),
-                date.getYear());
+        return date.format(FORMATTER_OUTPUT);
     }
 
 }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -15,6 +15,7 @@ import seedu.address.model.person.Person;
 public class PersonCard extends UiPart<Region> {
 
     private static final String FXML = "PersonListCard.fxml";
+    private static final String DATE_OF_BIRTH_PREAMBLE = "Date of Birth: ";
 
     /**
      * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
@@ -57,7 +58,7 @@ public class PersonCard extends UiPart<Region> {
         phone.setText(person.getPhone().value);
         address.setText(person.getAddress().value);
         email.setText(person.getEmail().value);
-        birthDate.setText(person.getBirthDate().toString());
+        birthDate.setText(DATE_OF_BIRTH_PREAMBLE + person.getBirthDate().toString());
         contactedInfo.setText(person.getContactedInfoList().get(0).toString());
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))

--- a/src/test/java/seedu/address/model/date/BirthDateTest.java
+++ b/src/test/java/seedu/address/model/date/BirthDateTest.java
@@ -18,7 +18,7 @@ class BirthDateTest {
 
     @Test
     public void parse_validString_success() {
-        assertEquals("1 JANUARY 2020", BirthDate.parse("2020-01-01").toString());
+        assertEquals("01 Jan 2020", BirthDate.parse("2020-01-01").toString());
     }
 
     @Test

--- a/src/test/java/seedu/address/model/date/DocumentedDateTest.java
+++ b/src/test/java/seedu/address/model/date/DocumentedDateTest.java
@@ -83,6 +83,6 @@ class DocumentedDateTest {
     @Test
     public void testToString_standardDate_success() {
         DocumentedDate date = new DocumentedDate(LocalDate.parse("2022-01-01"));
-        assertEquals("1 JANUARY 2022", date.toString());
+        assertEquals("01 Jan 2022", date.toString());
     }
 }

--- a/src/test/java/seedu/address/model/date/RecentDateTest.java
+++ b/src/test/java/seedu/address/model/date/RecentDateTest.java
@@ -18,7 +18,7 @@ class RecentDateTest {
 
     @Test
     public void parse_validString_success() {
-        assertEquals("1 JANUARY 2020", BirthDate.parse("2020-01-01").toString());
+        assertEquals("01 Jan 2020", BirthDate.parse("2020-01-01").toString());
     }
 
     @Test


### PR DESCRIPTION
Dates appear too aggressive and users do not know the displayed
date is the date of birth. This can be considered a feature flaw
by users.

Let's do the following to close AY2122S2-CS2103T-T17-3#69:
- Change the to string output of DocumentedDate objects
- Add a Date of birth label in PersonCard objects