### PR TITLE
Update how Description and RecentDate is parsed into ContactedInfo

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddContactedCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddContactedCommandParser.java
@@ -35,7 +35,6 @@ public class AddContactedCommandParser implements Parser<AddContactedInfoCommand
         }
 
         Index index;
-        ContactedInfo contactedInfo;
 
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
@@ -44,14 +43,9 @@ public class AddContactedCommandParser implements Parser<AddContactedInfoCommand
                     AddContactedInfoCommand.MESSAGE_USAGE), ive);
         }
 
-        try {
-            contactedInfo = ParserUtil.parseContactedInfo(
-                    argMultimap.getValue(PREFIX_CONTACTED_DATE).get(),
-                    argMultimap.getValue(PREFIX_CONTACTED_DESC).get());
-        } catch (IllegalArgumentException ive) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    AddContactedInfoCommand.MESSAGE_USAGE), ive);
-        }
+        ContactedInfo contactedInfo = ParserUtil.parseContactedInfo(
+                argMultimap.getValue(PREFIX_CONTACTED_DATE).get(),
+                argMultimap.getValue(PREFIX_CONTACTED_DESC).get());
 
         return new AddContactedInfoCommand(index, contactedInfo);
     }

--- a/src/main/java/seedu/address/logic/parser/AddContactedCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddContactedCommandParser.java
@@ -2,7 +2,6 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.commons.util.AppUtil.checkArgument;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACTED_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACTED_DESC;
 

--- a/src/main/java/seedu/address/logic/parser/AddContactedCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddContactedCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.util.AppUtil.checkArgument;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACTED_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACTED_DESC;
 
@@ -35,6 +36,7 @@ public class AddContactedCommandParser implements Parser<AddContactedInfoCommand
         }
 
         Index index;
+        ContactedInfo contactedInfo;
 
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
@@ -43,8 +45,14 @@ public class AddContactedCommandParser implements Parser<AddContactedInfoCommand
                     AddContactedInfoCommand.MESSAGE_USAGE), ive);
         }
 
-        ContactedInfo contactedInfo = ParserUtil.parseContactedInfo(argMultimap.getValue(PREFIX_CONTACTED_DATE).get(),
-                argMultimap.getValue(PREFIX_CONTACTED_DESC).get());
+        try {
+            contactedInfo = ParserUtil.parseContactedInfo(
+                    argMultimap.getValue(PREFIX_CONTACTED_DATE).get(),
+                    argMultimap.getValue(PREFIX_CONTACTED_DESC).get());
+        } catch (IllegalArgumentException ive) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddContactedInfoCommand.MESSAGE_USAGE), ive);
+        }
 
         return new AddContactedInfoCommand(index, contactedInfo);
     }

--- a/src/main/java/seedu/address/logic/parser/AddContactedCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddContactedCommandParser.java
@@ -5,6 +5,8 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACTED_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACTED_DESC;
 
+import java.util.stream.Stream;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.AddContactedInfoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -26,6 +28,12 @@ public class AddContactedCommandParser implements Parser<AddContactedInfoCommand
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_CONTACTED_DATE, PREFIX_CONTACTED_DESC);
 
+        if (!arePrefixesPresent(argMultimap, PREFIX_CONTACTED_DATE, PREFIX_CONTACTED_DESC)
+                || argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddContactedInfoCommand.MESSAGE_USAGE));
+        }
+
         Index index;
 
         try {
@@ -39,5 +47,13 @@ public class AddContactedCommandParser implements Parser<AddContactedInfoCommand
                 argMultimap.getValue(PREFIX_CONTACTED_DESC).get());
 
         return new AddContactedInfoCommand(index, contactedInfo);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -12,7 +12,9 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.contactedinfo.ContactedInfo;
 import seedu.address.model.date.BirthDate;
 import seedu.address.model.date.DocumentedDate;
+import seedu.address.model.date.RecentDate;
 import seedu.address.model.date.ReminderDate;
+import seedu.address.model.description.Description;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -114,7 +116,10 @@ public class ParserUtil {
         if (!ContactedInfo.isValidContactedInfo(trimmedDate, trimmedDescription)) {
             throw new ParseException(ContactedInfo.MESSAGE_CONSTRAINTS);
         }
-        return new ContactedInfo(trimmedDate, trimmedDescription);
+
+        RecentDate recentDate = RecentDate.parse(trimmedDate);
+        Description desc = new Description(trimmedDescription);
+        return new ContactedInfo(recentDate, desc);
     }
 
     /**

--- a/src/main/java/seedu/address/model/contactedinfo/ContactedInfo.java
+++ b/src/main/java/seedu/address/model/contactedinfo/ContactedInfo.java
@@ -1,7 +1,6 @@
 package seedu.address.model.contactedinfo;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import seedu.address.model.date.DocumentedDate;
 import seedu.address.model.date.RecentDate;
@@ -28,7 +27,6 @@ public class ContactedInfo implements Comparable<ContactedInfo> {
     public ContactedInfo(RecentDate recentDate, Description description) {
         requireNonNull(recentDate);
         requireNonNull(description);
-        checkArgument(isValidContactedInfo(recentDate.value, description.value), MESSAGE_CONSTRAINTS);
         this.description = description;
         this.recentDate = recentDate;
     }

--- a/src/main/java/seedu/address/model/contactedinfo/ContactedInfo.java
+++ b/src/main/java/seedu/address/model/contactedinfo/ContactedInfo.java
@@ -22,14 +22,15 @@ public class ContactedInfo implements Comparable<ContactedInfo> {
     /**
      * Constructs an {@code ContactedInfo}.
      *
-     * @param desc A valid description.
-     * @param date a valid date.
+     * @param recentDate A valid description.
+     * @param description a valid date.
      */
-    public ContactedInfo(String date, String desc) {
-        requireNonNull(date, desc);
-        checkArgument(isValidContactedInfo(date, desc), MESSAGE_CONSTRAINTS);
-        description = new Description(desc);
-        recentDate = RecentDate.parse(date);
+    public ContactedInfo(RecentDate recentDate, Description description) {
+        requireNonNull(recentDate);
+        requireNonNull(description);
+        checkArgument(isValidContactedInfo(recentDate.value, description.value), MESSAGE_CONSTRAINTS);
+        this.description = description;
+        this.recentDate = recentDate;
     }
 
     /**
@@ -38,7 +39,7 @@ public class ContactedInfo implements Comparable<ContactedInfo> {
      * @return the default contacted info.
      */
     public static ContactedInfo getDefaultContactedInfo() {
-        return new ContactedInfo(RecentDate.defaultRecentDateInStr(), Description.defaultDesc().toString());
+        return new ContactedInfo(RecentDate.defaultRecentDate(), Description.defaultDesc());
     }
 
     /**

--- a/src/main/java/seedu/address/model/date/RecentDate.java
+++ b/src/main/java/seedu/address/model/date/RecentDate.java
@@ -1,5 +1,7 @@
 package seedu.address.model.date;
 
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
@@ -28,6 +30,7 @@ public class RecentDate extends DocumentedDate implements Comparable<RecentDate>
      * @return A non null {@code RecentDate}.
      */
     public static RecentDate parse(String parsedDate) {
+        checkArgument(isValidDate(parsedDate));
         LocalDate date = LocalDate.parse(parsedDate);
         return new RecentDate(date);
     }

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -9,6 +9,8 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.contactedinfo.ContactedInfo;
 import seedu.address.model.date.BirthDate;
+import seedu.address.model.date.RecentDate;
+import seedu.address.model.description.Description;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -81,7 +83,9 @@ public class SampleDataUtil {
         return (ArrayList<ContactedInfo>) Arrays.stream(strings)
                 .map((str) -> {
                     String[] strArr = str.split(" ");
-                    return new ContactedInfo(strArr[0], strArr[1]);
+                    RecentDate recentDate = RecentDate.parse(strArr[0]);
+                    Description description = new Description(strArr[1]);
+                    return new ContactedInfo(recentDate, description);
                 })
                 .collect(Collectors.toList());
     }

--- a/src/main/java/seedu/address/storage/JsonAdaptedContactedInfo.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedContactedInfo.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.contactedinfo.ContactedInfo;
+import seedu.address.model.date.RecentDate;
+import seedu.address.model.description.Description;
 
 public class JsonAdaptedContactedInfo {
     private final String description;
@@ -38,6 +40,9 @@ public class JsonAdaptedContactedInfo {
         if (!ContactedInfo.isValidContactedInfo(date, description)) {
             throw new IllegalValueException(ContactedInfo.MESSAGE_CONSTRAINTS);
         }
-        return new ContactedInfo(date, description);
+
+        RecentDate recentDate = RecentDate.parse(date);
+        Description desc = new Description(description);
+        return new ContactedInfo(recentDate, desc);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/AddContactedInfoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddContactedInfoCommandTest.java
@@ -22,6 +22,8 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.contactedinfo.ContactedInfo;
+import seedu.address.model.date.RecentDate;
+import seedu.address.model.description.Description;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.PersonBuilder;
 
@@ -31,6 +33,10 @@ import seedu.address.testutil.PersonBuilder;
 public class AddContactedInfoCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private final Description validDescAmy = new Description(VALID_CONTACTED_DESC_AMY);
+    private final Description validDescBob = new Description(VALID_CONTACTED_DESC_BOB);
+    private final RecentDate validDateAmy = RecentDate.parse(VALID_CONTACTED_DATE_AMY);
+    private final RecentDate validDateBob = RecentDate.parse(VALID_CONTACTED_DATE_BOB);
 
     @Test
     public void constructor_anyFieldsNull_throwsNullPointerException() {
@@ -49,7 +55,7 @@ public class AddContactedInfoCommandTest {
         assertTrue(outOfBoundIndex.getZeroBased() >= model.getAddressBook().getPersonList().size());
 
         AddContactedInfoCommand contactedCommand = new AddContactedInfoCommand(
-                outOfBoundIndex, new ContactedInfo(VALID_CONTACTED_DATE_AMY, VALID_CONTACTED_DESC_AMY));
+                outOfBoundIndex, new ContactedInfo(validDateAmy, validDescAmy));
 
         assertCommandFailure(contactedCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
@@ -57,7 +63,7 @@ public class AddContactedInfoCommandTest {
     @Test
     public void execute_validIndex_success() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        ContactedInfo contactedInfo = new ContactedInfo(VALID_CONTACTED_DATE_AMY, VALID_CONTACTED_DESC_AMY);
+        ContactedInfo contactedInfo = new ContactedInfo(validDateAmy, validDescAmy);
 
         Person personToAddContactedLog = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Person expectedPerson = new PersonBuilder(personToAddContactedLog)
@@ -79,11 +85,11 @@ public class AddContactedInfoCommandTest {
     @Test
     public void equals() {
         final AddContactedInfoCommand standardCommand = new AddContactedInfoCommand(INDEX_FIRST_PERSON,
-                new ContactedInfo(VALID_CONTACTED_DATE_AMY, VALID_CONTACTED_DESC_AMY));
+                new ContactedInfo(validDateAmy, validDescAmy));
 
         // same values -> returns true
         AddContactedInfoCommand commandWithSameValues = new AddContactedInfoCommand(INDEX_FIRST_PERSON,
-                new ContactedInfo(VALID_CONTACTED_DATE_AMY, VALID_CONTACTED_DESC_AMY));
+                new ContactedInfo(validDateAmy, validDescAmy));
 
         assertTrue(standardCommand.equals(commandWithSameValues));
 
@@ -98,10 +104,10 @@ public class AddContactedInfoCommandTest {
 
         // different index -> returns false
         assertFalse(standardCommand.equals(new AddContactedInfoCommand(INDEX_SECOND_PERSON,
-                new ContactedInfo(VALID_CONTACTED_DATE_AMY, VALID_CONTACTED_DESC_AMY))));
+                new ContactedInfo(validDateAmy, validDescAmy))));
 
         // different remark -> returns false
         assertFalse(standardCommand.equals(new AddContactedInfoCommand(INDEX_SECOND_PERSON,
-                new ContactedInfo(VALID_CONTACTED_DATE_BOB, VALID_CONTACTED_DESC_BOB))));
+                new ContactedInfo(validDateBob, validDescBob))));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddContactedInfoCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddContactedInfoCommandParserTest.java
@@ -20,7 +20,7 @@ public class AddContactedInfoCommandParserTest {
     private static final String RECENT_DATE_EMPTY = " " + PREFIX_CONTACTED_DATE;
     private static final String RECENT_DESC_EMPTY = " " + PREFIX_CONTACTED_DESC;
     private final AddContactedCommandParser parser = new AddContactedCommandParser();
-    private final String nonEmptyDate = "2024-02-02";
+    private final String nonEmptyDate = "2020-02-02";
     private final String nonEmptyDesc = "Meeting";
     private final String validDate = RECENT_DATE_EMPTY + nonEmptyDate;
     private final String validDesc = RECENT_DESC_EMPTY + nonEmptyDesc;

--- a/src/test/java/seedu/address/logic/parser/AddContactedInfoCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddContactedInfoCommandParserTest.java
@@ -20,16 +20,24 @@ public class AddContactedInfoCommandParserTest {
     private static final String RECENT_DATE_EMPTY = " " + PREFIX_CONTACTED_DATE;
     private static final String RECENT_DESC_EMPTY = " " + PREFIX_CONTACTED_DESC;
     private final AddContactedCommandParser parser = new AddContactedCommandParser();
-    private final String nonEmptyDate = "2020-02-02";
+    private final String nonEmptyDate = "2024-02-02";
     private final String nonEmptyDesc = "Meeting";
+    private final String validDate = RECENT_DATE_EMPTY + nonEmptyDate;
+    private final String validDesc = RECENT_DESC_EMPTY + nonEmptyDesc;
 
     @Test
     public void parse_indexSpecified_success() {
 
         // have date and description
         Index targetIndex = INDEX_FIRST_PERSON;
-        String userInput = targetIndex.getOneBased() + " " + PREFIX_CONTACTED_DATE + nonEmptyDate + " "
+        String userInput =
+                targetIndex.getOneBased()
+                + " "
+                + PREFIX_CONTACTED_DATE
+                + nonEmptyDate
+                + " "
                 + PREFIX_CONTACTED_DESC + nonEmptyDesc;
+
         AddContactedInfoCommand expectedCommand = new AddContactedInfoCommand(INDEX_FIRST_PERSON,
                 new ContactedInfo(RecentDate.parse(nonEmptyDate), new Description(nonEmptyDesc)));
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -43,8 +51,25 @@ public class AddContactedInfoCommandParserTest {
         assertParseFailure(parser, AddContactedInfoCommand.COMMAND_WORD, expectedMessage);
 
         // no index
-        assertParseFailure(parser, AddContactedInfoCommand.COMMAND_WORD + " "
-                + nonEmptyDate + " " + nonEmptyDesc, expectedMessage);
+        assertParseFailure(parser, AddContactedInfoCommand.COMMAND_WORD
+                + " "
+                + validDate
+                + " "
+                + validDesc,
+                expectedMessage);
+
+        //no date
+        assertParseFailure(parser, AddContactedInfoCommand.COMMAND_WORD
+                + " 1 "
+                + validDesc,
+                expectedMessage);
+
+        //no description
+        assertParseFailure(parser, AddContactedInfoCommand.COMMAND_WORD
+                + " 1 "
+                + validDate,
+                expectedMessage);
+
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddContactedInfoCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddContactedInfoCommandParserTest.java
@@ -12,8 +12,13 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.AddContactedInfoCommand;
 import seedu.address.model.contactedinfo.ContactedInfo;
+import seedu.address.model.date.RecentDate;
+import seedu.address.model.description.Description;
 
 public class AddContactedInfoCommandParserTest {
+
+    private static final String RECENT_DATE_EMPTY = " " + PREFIX_CONTACTED_DATE;
+    private static final String RECENT_DESC_EMPTY = " " + PREFIX_CONTACTED_DESC;
     private final AddContactedCommandParser parser = new AddContactedCommandParser();
     private final String nonEmptyDate = "2020-02-02";
     private final String nonEmptyDesc = "Meeting";
@@ -26,7 +31,7 @@ public class AddContactedInfoCommandParserTest {
         String userInput = targetIndex.getOneBased() + " " + PREFIX_CONTACTED_DATE + nonEmptyDate + " "
                 + PREFIX_CONTACTED_DESC + nonEmptyDesc;
         AddContactedInfoCommand expectedCommand = new AddContactedInfoCommand(INDEX_FIRST_PERSON,
-                new ContactedInfo(nonEmptyDate, nonEmptyDesc));
+                new ContactedInfo(RecentDate.parse(nonEmptyDate), new Description(nonEmptyDesc)));
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 
@@ -40,5 +45,16 @@ public class AddContactedInfoCommandParserTest {
         // no index
         assertParseFailure(parser, AddContactedInfoCommand.COMMAND_WORD + " "
                 + nonEmptyDate + " " + nonEmptyDesc, expectedMessage);
+    }
+
+    @Test
+    public void constructor_invalidInputs_throwsIllegalArgumentException() {
+        String description = "";
+        assertParseFailure(parser, "1" + RECENT_DATE_EMPTY + RECENT_DESC_EMPTY,
+                ContactedInfo.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + RECENT_DATE_EMPTY + "hello " + RECENT_DESC_EMPTY + "meet up",
+                ContactedInfo.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + RECENT_DATE_EMPTY + RECENT_DESC_EMPTY + " ",
+                ContactedInfo.MESSAGE_CONSTRAINTS);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -35,6 +35,8 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.contactedinfo.ContactedInfo;
+import seedu.address.model.date.RecentDate;
+import seedu.address.model.description.Description;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.PersonWithTagPredicate;
@@ -140,12 +142,15 @@ public class AddressBookParserTest {
     public void parseCommand_contacted() throws Exception {
         final String date = "2020-02-02";
         final String desc = "Meeting";
+        final RecentDate recentDate = RecentDate.parse(date);
+        final Description description = new Description(desc);
         AddContactedInfoCommand command = (AddContactedInfoCommand) parser.parseCommand(
                 AddContactedInfoCommand.COMMAND_WORD + " "
                 + INDEX_FIRST_PERSON.getOneBased() + " "
                 + PREFIX_CONTACTED_DATE + date + " "
                 + PREFIX_CONTACTED_DESC + desc);
-        assertEquals(new AddContactedInfoCommand(INDEX_FIRST_PERSON, new ContactedInfo(date, desc)), command);
+        assertEquals(new AddContactedInfoCommand(INDEX_FIRST_PERSON,
+                new ContactedInfo(recentDate, description)), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/contactedinfo/ContactedInfoTest.java
+++ b/src/test/java/seedu/address/model/contactedinfo/ContactedInfoTest.java
@@ -10,40 +10,39 @@ import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.date.RecentDate;
+import seedu.address.model.description.Description;
+
 public class ContactedInfoTest {
     @Test
     public void constructor_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> new ContactedInfo(null, "meetup"));
-        assertThrows(NullPointerException.class, () -> new ContactedInfo("2020-02-02", null));
+
+        RecentDate recentDate = RecentDate.parse("2020-02-02");
+        Description description = new Description("meet up");
+        assertThrows(NullPointerException.class, () -> new ContactedInfo(null, description));
+        assertThrows(NullPointerException.class, () -> new ContactedInfo(recentDate, null));
         assertThrows(NullPointerException.class, () -> new ContactedInfo(null, null));
     }
 
     @Test
-    public void constructor_invalidDescription_throwsIllegalArgumentException() {
-        String description = "";
-        assertThrows(IllegalArgumentException.class, () -> new ContactedInfo("2020-02-02", description));
-    }
-
-    @Test
-    public void constructor_invalidDate_throwsIllegalArgumentException() {
-        String date = "not a date";
-        assertThrows(IllegalArgumentException.class, () -> new ContactedInfo(date, "meet up"));
-    }
-
-    @Test
     public void equals() {
-        ContactedInfo first = new ContactedInfo("2020-01-02", "phone call");
-        ContactedInfo second = new ContactedInfo("2021-02-01", "meeting");
+        ContactedInfo first = new ContactedInfo(RecentDate.parse("2020-01-02"), new Description("phone call"));
+        ContactedInfo second = new ContactedInfo(RecentDate.parse("2020-01-01"), new Description("meeting"));
 
         // same values -> returns true
-        assertTrue(new ContactedInfo(VALID_CONTACTED_DATE_AMY, VALID_CONTACTED_DESC_AMY).equals(
-                new ContactedInfo(VALID_CONTACTED_DATE_AMY, VALID_CONTACTED_DESC_AMY)));
+        assertTrue(
+                new ContactedInfo(RecentDate.parse(VALID_CONTACTED_DATE_AMY),
+                new Description(VALID_CONTACTED_DESC_AMY))
+                .equals(
+                new ContactedInfo(RecentDate.parse(VALID_CONTACTED_DATE_AMY),
+                new Description(VALID_CONTACTED_DESC_AMY))));
 
         // same object -> returns true
         assertTrue(first.equals(first));
 
         // null -> returns false
-        assertFalse(new ContactedInfo(VALID_CONTACTED_DATE_AMY, VALID_CONTACTED_DESC_AMY).equals(null));
+        assertFalse(new ContactedInfo(RecentDate.parse(VALID_CONTACTED_DATE_AMY),
+                new Description(VALID_CONTACTED_DESC_AMY)).equals(null));
 
         // different type -> returns false
         assertFalse(first.equals(5));
@@ -52,7 +51,11 @@ public class ContactedInfoTest {
         assertFalse(first.equals(second));
 
         // not equal
-        assertFalse(new ContactedInfo(VALID_CONTACTED_DATE_AMY, VALID_CONTACTED_DESC_AMY).equals(
-                new ContactedInfo(VALID_CONTACTED_DATE_BOB, VALID_CONTACTED_DESC_BOB)));
+        assertFalse(
+                new ContactedInfo(RecentDate.parse(VALID_CONTACTED_DATE_AMY),
+                new Description(VALID_CONTACTED_DESC_AMY))
+                .equals(
+                new ContactedInfo(RecentDate.parse(VALID_CONTACTED_DATE_BOB),
+                new Description(VALID_CONTACTED_DESC_BOB))));
     }
 }


### PR DESCRIPTION
This commit resolves https://github.com/AY2122S2-CS2103T-T17-3/tp/issues/73

Now, RecentDate and Descriptions objects are parsed into ContactedInfo.
test cases have been updated as well. Although it could be further
improved.