### PR TITLE
Clean up tagging feature improvement

### DIFF
--- a/src/main/java/seedu/address/logic/commands/HashtagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HashtagCommand.java
@@ -31,20 +31,6 @@ public class HashtagCommand extends Command {
         this.predicate = predicate;
     }
 
-    /**
-     * Returns true if the given input string is a hashtag (any string that starts with #).
-     *
-     * @param input the input string to verify.
-     * @return true if the given input string is a hashtag (any string that starts with #).
-     */
-    public static boolean isHashtagCommand(String input) {
-        if (input == null) {
-            return false;
-        }
-        String trimmedInput = input.trim();
-        return trimmedInput.startsWith(COMMAND_WORD);
-    }
-
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
@@ -55,8 +41,17 @@ public class HashtagCommand extends Command {
 
     @Override
     public boolean equals(Object other) {
-        return (other == this) // short circuit if same object
-                || (other instanceof HashtagCommand // instanceof handles nulls
-                && predicate.equals(((HashtagCommand) other).predicate)); // state check
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof HashtagCommand)) {
+            return false;
+        }
+
+        // state check
+        return predicate.equals(((HashtagCommand) other).predicate);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -20,7 +20,6 @@ import seedu.address.logic.commands.DeleteTagCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
-import seedu.address.logic.commands.HashtagCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListContactRemindersCommand;
@@ -49,8 +48,8 @@ public class AddressBookParser {
         final String trimmedUserInput = userInput.trim();
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(trimmedUserInput);
 
-        if (HashtagCommand.isHashtagCommand(trimmedUserInput)) { // in hashtag format, starts with #.
-            return new HashtagCommandParser().parse(trimmedUserInput.substring(1));
+        if (HashtagCommandParser.isHashtagCommand(trimmedUserInput)) { // in hashtag format, it starts with #.
+            return new HashtagCommandParser().parse(trimmedUserInput);
         }
 
         if (!matcher.matches()) {

--- a/src/main/java/seedu/address/logic/parser/HashtagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/HashtagCommandParser.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import seedu.address.logic.commands.HashtagCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -8,25 +10,65 @@ import seedu.address.model.person.PersonWithTagPredicate;
 import seedu.address.model.tag.Tag;
 
 /**
- * Parses input arguments and creates a new HashtagCommand object
+ * Parses input arguments and creates a new {@code HashtagCommand} object.
  */
 public class HashtagCommandParser implements Parser<HashtagCommand> {
 
+    public static final Prefix PREFIX_HASHTAG = new Prefix(HashtagCommand.COMMAND_WORD);
+    public static final String MESSAGE_CONSTRAINT = String.format("input should start with %1$s",
+            HashtagCommand.COMMAND_WORD);
+
     /**
-     * Parses the given tag of {@code String} type in the context of the HashtagCommand
-     * and returns a HashtagCommand object for execution.
+     * Parses the given tag of {@code String} type in the context of the {@code HashtagCommand}
+     * and returns a {@code HashtagCommand} object for execution. {@code isHashtagCommand(String) } must be called and
+     * checked before this method call.
      *
+     * @param input the hashtag command to be parsed.
+     * @return a new {@code HashtagCommand} object
      * @throws ParseException if the user input does not conform the expected format,
      *                        either the given tag is empty or invalid (not alphanumerical).
+     * @see HashtagCommand
+     * @see #isHashtagCommand(String)
      */
     @Override
     public HashtagCommand parse(String input) throws ParseException {
-        String trimmedInput = input.trim();
-        if (trimmedInput.isEmpty()) {
+        checkArgument(HashtagCommandParser.isHashtagCommand(input), MESSAGE_CONSTRAINT);
+
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(trimAndAddOneLeadingSpace(input), PREFIX_HASHTAG);
+
+        String tagName = argMultimap.getValue(PREFIX_HASHTAG).get();
+        if (tagName.isBlank()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, HashtagCommand.MESSAGE_USAGE));
         }
-        Tag newTag = ParserUtil.parseTag(trimmedInput);
+
+        Tag newTag = ParserUtil.parseTag(tagName);
         return new HashtagCommand(new PersonWithTagPredicate(newTag));
+    }
+
+    /**
+     * Returns true if the given input string is a hashtag command (any string that starts with #).
+     *
+     * @param input the input string to verify.
+     * @return true if the given input string is a hashtag command (any string that starts with #).
+     */
+    public static boolean isHashtagCommand(String input) {
+        requireNonNull(input);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(trimAndAddOneLeadingSpace(input), PREFIX_HASHTAG);
+        return argMultimap.getValue(PREFIX_HASHTAG).isPresent() && argMultimap.getPreamble().isEmpty();
+    }
+
+    /**
+     * Trims the input string and add a leading space, used for {@code ArgumentTokenizer#tokenize(String, Prefix...)},
+     * that requires its {@code String} input to be preceding with a space.
+     *
+     * @param input the {@code String} to be processed.
+     * @return trimmed input with one leading space.
+     * @see ArgumentTokenizer#tokenize(String, Prefix...)
+     */
+    private static String trimAndAddOneLeadingSpace(String input) {
+        requireNonNull(input);
+        String trimmedInput = input.trim();
+        return " " + trimmedInput;
     }
 }

--- a/src/test/java/seedu/address/logic/commands/AddTagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddTagCommandTest.java
@@ -25,7 +25,7 @@ import seedu.address.testutil.PersonBuilder;
 
 class AddTagCommandTest {
 
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
     public void constructor_anyFieldsNull_throwsNullPointerException() {
@@ -168,7 +168,7 @@ class AddTagCommandTest {
         // null -> returns false
         assertFalse(addTagFirstCommand.equals(null));
 
-        // different person -> returns false
+        // different command -> returns false
         assertFalse(addTagFirstCommand.equals(addTagSecondCommand));
         assertFalse(addTagFirstCommand.equals(addTagThirdCommand));
         assertFalse(addTagFirstCommand.equals(addTagFourthCommand));

--- a/src/test/java/seedu/address/logic/commands/DeleteTagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteTagCommandTest.java
@@ -155,7 +155,7 @@ public class DeleteTagCommandTest {
         // null -> returns false
         assertFalse(deleteTagFirstCommand.equals(null));
 
-        // different person -> returns false
+        // different command -> returns false
         assertFalse(deleteTagFirstCommand.equals(deleteTagSecondCommand));
         assertFalse(deleteTagFirstCommand.equals(deleteTagThirdCommand));
         assertFalse(deleteTagFirstCommand.equals(deleteTagFourthCommand));

--- a/src/test/java/seedu/address/logic/commands/HashtagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HashtagCommandTest.java
@@ -23,22 +23,8 @@ import seedu.address.model.tag.Tag;
 
 class HashtagCommandTest {
 
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-
-    @Test
-    public void isHashtagCommand_isHashtagCommand_returnsTrue() {
-        assertTrue(HashtagCommand.isHashtagCommand(" #test"));
-        assertTrue(HashtagCommand.isHashtagCommand("#test"));
-        assertTrue(HashtagCommand.isHashtagCommand("#test 123"));
-    }
-
-    @Test
-    public void isHashtagCommand_notHashtagCommand_returnFalse() {
-        assertFalse(HashtagCommand.isHashtagCommand(null));
-        assertFalse(HashtagCommand.isHashtagCommand("find"));
-        assertFalse(HashtagCommand.isHashtagCommand("notTag#test"));
-    }
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private final Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
     public void execute_noMatchingTag_noPersonFound() {

--- a/src/test/java/seedu/address/logic/parser/AddTagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddTagCommandParserTest.java
@@ -23,7 +23,7 @@ class AddTagCommandParserTest {
     private static final String MESSAGE_INVALID_FORMAT =
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddTagCommand.MESSAGE_USAGE);
 
-    private AddTagCommandParser parser = new AddTagCommandParser();
+    private final AddTagCommandParser parser = new AddTagCommandParser();
 
     @Test
     public void parse_noTag_failure() {
@@ -69,7 +69,7 @@ class AddTagCommandParserTest {
 
     @Test
     public void parse_allFieldsSpecified_success() {
-        // vanilla
+        // basic format
         AddTagCommand expectedCommand = new AddTagCommand(INDEX_FIRST_PERSON, new Tag(VALID_TAG_FRIEND));
         assertParseSuccess(parser, INDEX_FIRST_PERSON.getOneBased() + TAG_EMPTY + VALID_TAG_FRIEND, expectedCommand);
 

--- a/src/test/java/seedu/address/logic/parser/DeleteTagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteTagCommandParserTest.java
@@ -73,7 +73,7 @@ public class DeleteTagCommandParserTest {
 
     @Test
     public void parse_allFieldsSpecified_success() {
-        // vanilla
+        // basic format
         DeleteTagCommand expectedCommand = new DeleteTagCommand(INDEX_FIRST_PERSON, new Tag(VALID_TAG_FRIEND));
         assertParseSuccess(parser, INDEX_FIRST_PERSON.getOneBased() + TAG_EMPTY + VALID_TAG_FRIEND, expectedCommand);
 

--- a/src/test/java/seedu/address/logic/parser/HashtagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/HashtagCommandParserTest.java
@@ -1,5 +1,8 @@
 package seedu.address.logic.parser;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -12,16 +15,22 @@ import seedu.address.model.tag.Tag;
 
 class HashtagCommandParserTest {
 
-    private HashtagCommandParser parser = new HashtagCommandParser();
+    private final HashtagCommandParser parser = new HashtagCommandParser();
 
     @Test
-    public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "   ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, HashtagCommand.MESSAGE_USAGE));
+    public void parse_notHashtagCommand_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> parser.parse("random"));
+        assertThrows(IllegalArgumentException.class, () -> parser.parse("random input"));
+        assertThrows(IllegalArgumentException.class, () -> parser.parse("   "));
+        assertThrows(IllegalArgumentException.class, () -> parser.parse(""));
     }
 
     @Test
     public void parse_notAlphanumeric_throwsParseException() {
-        assertParseFailure(parser, "not alphanumeric", Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "#not alphanumeric", Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "#no#$@", Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "#",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, HashtagCommand.MESSAGE_USAGE));
     }
 
     @Test
@@ -29,10 +38,31 @@ class HashtagCommandParserTest {
         HashtagCommand expectedHashtagCommand =
                 new HashtagCommand(new PersonWithTagPredicate(new Tag("friends")));
 
-        // vanilla
-        assertParseSuccess(parser, "friends", expectedHashtagCommand);
+        // basic format
+        assertParseSuccess(parser, "#friends", expectedHashtagCommand);
+
+        // space before tag
+        assertParseSuccess(parser, "# friends", expectedHashtagCommand);
 
         // leading and trailing spaces
-        assertParseSuccess(parser, " \n \t friends \n \t ", expectedHashtagCommand);
+        assertParseSuccess(parser, " \n \t #friends \n \t ", expectedHashtagCommand);
+    }
+
+    @Test
+    public void isHashtagCommand_isHashtagCommand_returnsTrue() {
+        assertTrue(HashtagCommandParser.isHashtagCommand(" #test"));
+        assertTrue(HashtagCommandParser.isHashtagCommand("#test"));
+        assertTrue(HashtagCommandParser.isHashtagCommand("#test 123"));
+    }
+
+    @Test
+    public void isHashtagCommand_notHashtagCommand_returnFalse() {
+        assertFalse(HashtagCommandParser.isHashtagCommand("find"));
+        assertFalse(HashtagCommandParser.isHashtagCommand("notTag#test"));
+    }
+
+    @Test
+    public void isHashtagCommand_nullInput_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> HashtagCommandParser.isHashtagCommand(null));
     }
 }


### PR DESCRIPTION
Fix SLAP violation for HashtagCommandParser

Some parsing process of HashtagCommandParser was done in
AddressBookParser and violates the SLAP and SRP.

This commit also upgrades the HashtagCommandParser, by using
ArgumentTokenizer.tokenize method using hashtag prefix, that uses the
existing classes rather than writing primitive statements, like
.substring and .startsWith.

Let's
* Shift isHashtagCommand to HashtagCommandParser
* Utilise ArgumentTokenizer.tokenize in isHashtagCommand
* Utilise ArgumentTokenizer.tokenize in HashtagCommandParser
* Shift isHashtagCommand test cases to HashtagCommandParserTest
* Make minor changes to HashtagCommandParserTest for the changes made

Fix minor typos, improve equals' implementation

Closes #37.