### PR TITLE
Add check for Recent Date Objects

### DIFF
--- a/src/main/java/seedu/address/model/contactedinfo/ContactedInfo.java
+++ b/src/main/java/seedu/address/model/contactedinfo/ContactedInfo.java
@@ -11,8 +11,8 @@ import seedu.address.model.description.Description;
  */
 public class ContactedInfo implements Comparable<ContactedInfo> {
     public static final String MESSAGE_CONSTRAINTS =
-            "Only 1 date and description should be given, both fields are needed as well, "
-            + RecentDate.MESSAGE_CONSTRAINTS + " and " + Description.MESSAGE_CONSTRAINTS;
+            "You should provide a valid date and description.\n"
+            + RecentDate.MESSAGE_CONSTRAINTS + " and should not be in the future.\n" + Description.MESSAGE_CONSTRAINTS;
 
     private final Description description;
     private final RecentDate recentDate;
@@ -47,7 +47,9 @@ public class ContactedInfo implements Comparable<ContactedInfo> {
      * @return true if a given string is a valid contacted information.
      */
     public static boolean isValidContactedInfo(String dateTest, String descriptionTest) {
-        return DocumentedDate.isValidDate(dateTest) && Description.isValidDescription(descriptionTest);
+        return DocumentedDate.isValidDate(dateTest)
+                && Description.isValidDescription(descriptionTest)
+                && RecentDate.isValidRecentDate(dateTest);
     }
 
     /**
@@ -59,8 +61,15 @@ public class ContactedInfo implements Comparable<ContactedInfo> {
         return recentDate;
     }
 
+    /**
+     * Returns the number of days passed since the saved ContactedDate.
+     *
+     * @return an integer representing the number of days passed.
+     */
     public Integer getDaysPassed() {
-        return recentDate.getDaysPassed();
+        int daysPassed = recentDate.getDaysPassed();
+        assert daysPassed >= 0 : "Days passed should not be less than 0";
+        return daysPassed;
     }
 
     /**

--- a/src/main/java/seedu/address/model/date/RecentDate.java
+++ b/src/main/java/seedu/address/model/date/RecentDate.java
@@ -1,5 +1,6 @@
 package seedu.address.model.date;
 
+import static java.time.temporal.ChronoUnit.DAYS;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import java.time.LocalDate;
@@ -33,6 +34,15 @@ public class RecentDate extends DocumentedDate implements Comparable<RecentDate>
         checkArgument(isValidDate(parsedDate));
         LocalDate date = LocalDate.parse(parsedDate);
         return new RecentDate(date);
+    }
+
+    /**
+     * Returns true if a given string can be converted to a date
+     * that has either occurred today or in the past.
+     */
+    public static boolean isValidRecentDate(String test) {
+        LocalDate testDate = LocalDate.parse(test);
+        return DAYS.between(testDate, LocalDate.now()) >= 0;
     }
 
     /**

--- a/src/test/java/seedu/address/model/date/RecentDateTest.java
+++ b/src/test/java/seedu/address/model/date/RecentDateTest.java
@@ -3,33 +3,59 @@ package seedu.address.model.date;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.model.date.RecentDate.isValidRecentDate;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 
 
 class RecentDateTest {
     private static final DateTimeFormatter FORMATTER_INPUT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    private LocalDate test;
+    private LocalDate tomorrow;
+    private String testString;
+    private String tomorrowString;
 
+    @BeforeEach
+    public void setUp() {
+        test = LocalDate.now();
+        tomorrow = LocalDate.now().plusDays(1);
+        testString = test.format(FORMATTER_INPUT);
+        tomorrowString = tomorrow.format(FORMATTER_INPUT);
+    }
     @Test
     public void parse_validString_success() {
-        assertEquals("01 Jan 2020", BirthDate.parse("2020-01-01").toString());
+        assertEquals("01 Jan 2020", RecentDate.parse("2020-01-01").toString());
     }
 
     @Test
     public void parse_invalidString_failure() {
-        assertThrows(DateTimeParseException.class, ()->BirthDate.parse("hello"));
+        assertThrows(IllegalArgumentException.class, ()->RecentDate.parse("hello"));
+    }
+
+    @Test
+    public void isValidRecentDate_variousInput() {
+        assertTrue(isValidRecentDate(testString));
+        assertFalse(isValidRecentDate(tomorrowString));
+        LocalDate yesterday = test.minusDays(1);
+        String yesterdayString = yesterday.format(FORMATTER_INPUT);
+        assertTrue(isValidRecentDate(yesterdayString));
+        LocalDate future = test.plusMonths(1);
+        String futureString = future.format(FORMATTER_INPUT);
+        assertFalse(isValidRecentDate(futureString));
+        LocalDate nextYear = test.plusYears(1);
+        String nextYearString = nextYear.format(FORMATTER_INPUT);
+        assertFalse(isValidRecentDate(nextYearString));
+
     }
 
     @Test
     public void equals() {
-        LocalDate test = LocalDate.now();
-        LocalDate tomorrow = LocalDate.now().plusDays(1);
         RecentDate testRecentDate = new RecentDate(test);
         RecentDate nextDay = new RecentDate(tomorrow);
         String testString = test.format(FORMATTER_INPUT);


### PR DESCRIPTION
ContactedInfo objects can be created with future dates. This will
cause bugs because you will have an inaccurate output from the
getDaysPassed method.

Let's do the following to close AY2122S2-CS2103T-T17-3#108:
- Add a check in the RecentDate class
- Update the isValidContactedInfo method
- Add an assertion in the getDaysPassed method
- Perform adequate testing on the new check