### PR TITLE
Fix text formatting in result display

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -43,7 +43,7 @@ e.g. "exe" refers to the executable file type used on windows.
   - [Deleting a tag: `untag`](#deleting-a-tag-untag)
   - [Viewiing all available tags: `tags`](#viewing-all-available-tags-tags)
   - [Finding contacts with tag: `#`](#finding-contacts-with-tag-)
-  - [Adding interaction records with a contact: `contacted`](#adding-interaction-records-with-a-contact-contacted)
+  - [Adding interaction records with a contact: `log`](#adding-interaction-records-with-a-contact-log)
   - [Deleting a recent interaction record with a contact: `unlog`](#deleting-a-recent-interaction-record-with-a-contact-unlog)
   - [Viewing all recent interactions with a contact: `logs`](#viewing-all-recent-interactions-with-a-contact-logs)
   - [Viewing contacts that were contacted within days: `within`](#viewing-contacts-that-were-contacted-within-days-within)
@@ -240,15 +240,15 @@ Example:
 
 [Return to Table of Contents](#table-of-contents)
 
-### Adding interaction records with a contact: `contacted`
+### Adding interaction records with a contact: `log`
 
-After meeting a client, you might want to write a note about the client, along with the meeting date. By using the `contacted` command, you can manually save your interaction with the person in the form of a note accompanied by a date.
+After meeting a client, you might want to write a note about the client, along with the meeting date. By using the `log` command, you can manually save your interaction with the person in the form of a note accompanied by a date.
 
-Format: `contacted INDEX d/DATE des/description`
+Format: `log INDEX d/DATE des/description`
 * `DATE` should be in the specified date format.
 
 Example:
-* `contacted 23 d/2022-02-11 des/Signed contract` manually logs the following interaction with the 23rd person in the displayed contact list, `Signed contract` on `2022-02-11`.
+* `log 23 d/2022-02-11 des/Signed contract` manually logs the following interaction with the 23rd person in the displayed contact list, `Signed contract` on `2022-02-11`.
 
 [Return to Table of Contents](#table-of-contents)
 
@@ -398,7 +398,7 @@ If you made a mistake while manually editing the saved data, a backup save file 
 | **Delete a recorded interaction with a contact**         | `unlog INDEX del/INDEX`                                                               |
 | **View all recorded interactions with a contact**        | `logs INDEX`                                                                          |
 | **View people contacted within DAYS**                    | `within DAYS`                                                                         |
-| **View people you have contacted more than DAYS** ago    | `after DAYS`                                                                          |
+| **View people you have contacted more than DAYS ago**    | `after DAYS`                                                                          |
 | **View birthdays occurring today**                       | `birthdays`                                                                           |
 | **Add a reminder**                                       | `remind INDEX r/REMINDER rd/DATE`                                                     |
 | **View reminders of a contact**                          | `reminder INDEX`                                                                      |

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -83,10 +83,10 @@ public class MainApp extends Application {
             }
             initialData = addressBookOptional.orElseGet(SampleDataUtil::getSampleAddressBook);
         } catch (DataConversionException e) {
-            logger.warning("Data file not in the correct format. Will be starting with an empty save file");
+            logger.warning("Data file not in the correct format. Will be starting with an empty data file");
             initialData = new AddressBook();
         } catch (IOException e) {
-            logger.warning("Problem while reading from the file. Will be starting with an empty save file");
+            logger.warning("Problem while reading from the file. Will be starting with an empty data file");
             initialData = new AddressBook();
         }
 
@@ -151,7 +151,7 @@ public class MainApp extends Application {
                     + "Using default user prefs");
             initializedPrefs = new UserPrefs();
         } catch (IOException e) {
-            logger.warning("Problem while reading from the file. Will be starting with an empty save file");
+            logger.warning("Problem while reading from the file. Will be starting with an empty data file");
             initializedPrefs = new UserPrefs();
         }
 

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -36,7 +36,7 @@ import seedu.address.ui.UiManager;
  */
 public class MainApp extends Application {
 
-    public static final Version VERSION = new Version(0, 2, 0, true);
+    public static final Version VERSION = new Version(1, 3, 0, false);
 
     private static final Logger logger = LogsCenter.getLogger(MainApp.class);
 
@@ -48,7 +48,7 @@ public class MainApp extends Application {
 
     @Override
     public void init() throws Exception {
-        logger.info("=============================[ Initializing AddressBook ]===========================");
+        logger.info("=============================[ Initializing AIA Application ]===========================");
         super.init();
 
         AppParameters appParameters = AppParameters.parse(getParameters());
@@ -79,14 +79,14 @@ public class MainApp extends Application {
         try {
             addressBookOptional = storage.readAddressBook();
             if (!addressBookOptional.isPresent()) {
-                logger.info("Data file not found. Will be starting with a sample AddressBook");
+                logger.info("Data file not found. Will be starting with a sample data file");
             }
             initialData = addressBookOptional.orElseGet(SampleDataUtil::getSampleAddressBook);
         } catch (DataConversionException e) {
-            logger.warning("Data file not in the correct format. Will be starting with an empty AddressBook");
+            logger.warning("Data file not in the correct format. Will be starting with an empty save file");
             initialData = new AddressBook();
         } catch (IOException e) {
-            logger.warning("Problem while reading from the file. Will be starting with an empty AddressBook");
+            logger.warning("Problem while reading from the file. Will be starting with an empty save file");
             initialData = new AddressBook();
         }
 
@@ -151,7 +151,7 @@ public class MainApp extends Application {
                     + "Using default user prefs");
             initializedPrefs = new UserPrefs();
         } catch (IOException e) {
-            logger.warning("Problem while reading from the file. Will be starting with an empty AddressBook");
+            logger.warning("Problem while reading from the file. Will be starting with an empty save file");
             initializedPrefs = new UserPrefs();
         }
 
@@ -167,13 +167,13 @@ public class MainApp extends Application {
 
     @Override
     public void start(Stage primaryStage) {
-        logger.info("Starting AddressBook " + MainApp.VERSION);
+        logger.info("Starting AIA Application " + MainApp.VERSION);
         ui.start(primaryStage);
     }
 
     @Override
     public void stop() {
-        logger.info("============================ [ Stopping Address Book ] =============================");
+        logger.info("============================ [ Stopping AIA Application ] =============================");
         try {
             storage.saveUserPrefs(model.getUserPrefs());
         } catch (IOException e) {

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -5,7 +5,7 @@ package seedu.address.commons.core;
  */
 public class Messages {
 
-    public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
+    public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command. Use 'help' to view user guide";
     public static final String MESSAGE_INVALID_ARGUMENTS = "Arguments are not allowed after this command word!";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -41,14 +41,8 @@ public class LogicManager implements Logic {
     public CommandResult execute(String commandText) throws CommandException, ParseException {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
 
-        CommandResult commandResult;
-        Command command = null;
-        try {
-            command = addressBookParser.parseCommand(commandText);
-        } catch (java.text.ParseException e) {
-            e.printStackTrace();
-        }
-        commandResult = command.execute(model);
+        Command command = addressBookParser.parseCommand(commandText);
+        CommandResult commandResult = command.execute(model);
 
         try {
             storage.saveAddressBook(model.getAddressBook());

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -41,10 +41,8 @@ public class LogicManager implements Logic {
     public CommandResult execute(String commandText) throws CommandException, ParseException {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
 
-        CommandResult commandResult;
-
         Command command = addressBookParser.parseCommand(commandText);
-        commandResult = command.execute(model);
+        CommandResult commandResult = command.execute(model);
 
         try {
             storage.saveAddressBook(model.getAddressBook());

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -41,8 +41,10 @@ public class LogicManager implements Logic {
     public CommandResult execute(String commandText) throws CommandException, ParseException {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
 
+        CommandResult commandResult;
+
         Command command = addressBookParser.parseCommand(commandText);
-        CommandResult commandResult = command.execute(model);
+        commandResult = command.execute(model);
 
         try {
             storage.saveAddressBook(model.getAddressBook());

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -30,7 +30,7 @@ public class AddCommand extends Command {
             + PREFIX_BIRTH_DATE + "BIRTHDATE "
             + PREFIX_CONTACTED_DATE + "CONTACTED_DATE "
             + PREFIX_CONTACTED_DESC + "DESC "
-            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "[" + PREFIX_TAG + "TAG]...\n\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -21,13 +21,13 @@ public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book. "
-            + "Parameters: "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Saves a person as a contact. "
+            + "\n\nParameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
-            + PREFIX_BIRTH_DATE + "BIRTHDATE "
+            + PREFIX_BIRTH_DATE + "BIRTH_DATE "
             + PREFIX_CONTACTED_DATE + "CONTACTED_DATE "
             + PREFIX_CONTACTED_DESC + "DESC "
             + "[" + PREFIX_TAG + "TAG]...\n\n"
@@ -41,7 +41,7 @@ public class AddCommand extends Command {
             + PREFIX_TAG + "owesMoney";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person is already saved as a contact";
 
     private final Person toAdd;
 

--- a/src/main/java/seedu/address/logic/commands/AddContactedInfoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddContactedInfoCommand.java
@@ -19,13 +19,14 @@ import seedu.address.model.person.Person;
  */
 public class AddContactedInfoCommand extends Command {
 
-    public static final String MESSAGE_ADD_INTERACTION_SUCCESS = "Recorded interaction with Person: %1$s";
+    public static final String MESSAGE_ADD_INTERACTION_SUCCESS = "Recorded interaction with %1$s"
+            + "\n\nSaved interaction as:\n%2$s";
     public static final String MESSAGE_DUPLICATE_CONTACTED_INFO = "Interaction records already contains: %1$s";
 
     public static final String COMMAND_WORD = "log";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Adds the last contacted date  "
-            + "by the index number used in the last person listing. "
+            + "by the index number used in the displayed contact list. "
             + "Existing date will be overwritten by the input.\n\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "d/ [DATE] "
@@ -89,7 +90,8 @@ public class AddContactedInfoCommand extends Command {
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
-        return new CommandResult(String.format(MESSAGE_ADD_INTERACTION_SUCCESS, editedPerson));
+        return new CommandResult(
+                String.format(MESSAGE_ADD_INTERACTION_SUCCESS, editedPerson.getName(), contactedInfo.toString()));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/AddContactedInfoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddContactedInfoCommand.java
@@ -19,17 +19,17 @@ import seedu.address.model.person.Person;
  */
 public class AddContactedInfoCommand extends Command {
 
-    public static final String MESSAGE_ADD_CONTACTEDINFO_SUCCESS = "Added Contacted Info to Person: %1$s";
-    public static final String MESSAGE_DUPLICATE_CONTACTED_INFO = "Contacted list already contains: %1$s";
+    public static final String MESSAGE_ADD_INTERACTION_SUCCESS = "Recorded interaction with Person: %1$s";
+    public static final String MESSAGE_DUPLICATE_CONTACTED_INFO = "Interaction records already contains: %1$s";
 
-    public static final String COMMAND_WORD = "contacted";
+    public static final String COMMAND_WORD = "log";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Adds the last contacted date  "
             + "by the index number used in the last person listing. "
-            + "Existing date will be overwritten by the input.\n"
+            + "Existing date will be overwritten by the input.\n\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "d/ [DATE] "
-            + "des/ [DESCRIPTION]\n"
+            + "des/ [DESCRIPTION]\n\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + "d/ 2020-02-02 "
             + "des/ meetup.";
@@ -89,7 +89,7 @@ public class AddContactedInfoCommand extends Command {
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
-        return new CommandResult(String.format(MESSAGE_ADD_CONTACTEDINFO_SUCCESS, editedPerson));
+        return new CommandResult(String.format(MESSAGE_ADD_INTERACTION_SUCCESS, editedPerson));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/AddTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTagCommand.java
@@ -31,7 +31,7 @@ public class AddTagCommand extends Command {
     public static final String COMMAND_WORD = "tag";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Tags a contact to a category, "
-            + "as specified by the index number used in the displayed person list. The tag will be added only if "
+            + "as specified by the index number used in the displayed contact list. The tag will be added only if "
             + "the tag is valid and is not already tagged to the contact (case-insensitive).\n\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_TAG + "TAG]\n\n"

--- a/src/main/java/seedu/address/logic/commands/AddTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTagCommand.java
@@ -30,11 +30,11 @@ public class AddTagCommand extends Command {
 
     public static final String COMMAND_WORD = "tag";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a tag to the tags of an existing contact, "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Tags a contact to a category, "
             + "as specified by the index number used in the displayed person list. The tag will be added only if "
-            + "the tag is valid and is not already tagged to the contact (case-insensitive).\n"
+            + "the tag is valid and is not already tagged to the contact (case-insensitive).\n\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + "[" + PREFIX_TAG + "TAG]\n"
+            + "[" + PREFIX_TAG + "TAG]\n\n"
             + "Example: " + COMMAND_WORD + " 2 "
             + PREFIX_TAG + "friends";
 

--- a/src/main/java/seedu/address/logic/commands/BirthdayCommand.java
+++ b/src/main/java/seedu/address/logic/commands/BirthdayCommand.java
@@ -16,7 +16,7 @@ public class BirthdayCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Here are the people with birthdays today.\n"
                                                     + Messages.MESSAGE_PERSONS_LISTED_OVERVIEW
-                                                    + "\nSend them a birthday message!";
+                                                    + "\n\nSend them a birthday message!";
     /**
      * Executes the command and returns the result message.
      *

--- a/src/main/java/seedu/address/logic/commands/ContactedOutsideRangeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ContactedOutsideRangeCommand.java
@@ -13,7 +13,7 @@ import seedu.address.model.person.PersonOutsideDateRangePredicate;
 public class ContactedOutsideRangeCommand extends Command {
 
     public static final String COMMAND_WORD = "after";
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons contacted outside "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Find all contacts contacted outside "
             + "the specified range of days and displays them as a list with index numbers.\n\n"
             + "Parameters: number of days (Positive integer or 0)\n\n"
             + "Example: " + COMMAND_WORD + " 5";

--- a/src/main/java/seedu/address/logic/commands/ContactedOutsideRangeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ContactedOutsideRangeCommand.java
@@ -13,9 +13,9 @@ import seedu.address.model.person.PersonOutsideDateRangePredicate;
 public class ContactedOutsideRangeCommand extends Command {
 
     public static final String COMMAND_WORD = "after";
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all contacts contacted outside "
-            + "the specified range of days and displays them as a list with index numbers.\n"
-            + "Parameters: number of days (Positive integer or 0)\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons contacted outside "
+            + "the specified range of days and displays them as a list with index numbers.\n\n"
+            + "Parameters: number of days (Positive integer or 0)\n\n"
             + "Example: " + COMMAND_WORD + " 5";
     private final PersonOutsideDateRangePredicate predicate;
 

--- a/src/main/java/seedu/address/logic/commands/ContactedOutsideRangeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ContactedOutsideRangeCommand.java
@@ -13,7 +13,7 @@ import seedu.address.model.person.PersonOutsideDateRangePredicate;
 public class ContactedOutsideRangeCommand extends Command {
 
     public static final String COMMAND_WORD = "after";
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Find all contacts contacted outside "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all contacts contacted outside "
             + "the specified range of days and displays them as a list with index numbers.\n\n"
             + "Parameters: number of days (Positive integer or 0)\n\n"
             + "Example: " + COMMAND_WORD + " 5";

--- a/src/main/java/seedu/address/logic/commands/ContactedWithinRangeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ContactedWithinRangeCommand.java
@@ -13,9 +13,9 @@ import seedu.address.model.person.PersonWithinDateRangePredicate;
 public class ContactedWithinRangeCommand extends Command {
 
     public static final String COMMAND_WORD = "within";
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all contacts contacted within "
-            + "the specified range of days and displays them as a list with index numbers.\n"
-            + "Parameters: number of days (Positive integer or 0)\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons contacted within "
+            + "the specified range of days and displays them as a list with index numbers.\n\n"
+            + "Parameters: number of days (Positive integer or 0)\n\n"
             + "Example: " + COMMAND_WORD + " 5";
     private final PersonWithinDateRangePredicate predicate;
 

--- a/src/main/java/seedu/address/logic/commands/ContactedWithinRangeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ContactedWithinRangeCommand.java
@@ -13,7 +13,7 @@ import seedu.address.model.person.PersonWithinDateRangePredicate;
 public class ContactedWithinRangeCommand extends Command {
 
     public static final String COMMAND_WORD = "within";
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons contacted within "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Find all contacts contacted within "
             + "the specified range of days and displays them as a list with index numbers.\n\n"
             + "Parameters: number of days (Positive integer or 0)\n\n"
             + "Example: " + COMMAND_WORD + " 5";

--- a/src/main/java/seedu/address/logic/commands/ContactedWithinRangeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ContactedWithinRangeCommand.java
@@ -13,7 +13,7 @@ import seedu.address.model.person.PersonWithinDateRangePredicate;
 public class ContactedWithinRangeCommand extends Command {
 
     public static final String COMMAND_WORD = "within";
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Find all contacts contacted within "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all contacts contacted within "
             + "the specified range of days and displays them as a list with index numbers.\n\n"
             + "Parameters: number of days (Positive integer or 0)\n\n"
             + "Example: " + COMMAND_WORD + " 5";

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -18,7 +18,7 @@ public class DeleteCommand extends Command {
     public static final String COMMAND_WORD = "delete";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the person identified by the index number used in the displayed person list.\n\n"
+            + ": Deletes the person identified by the index number used in the displayed contact list.\n\n"
             + "Parameters: INDEX (must be a positive integer)\n\n"
             + "Example: " + COMMAND_WORD + " 1";
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -18,8 +18,8 @@ public class DeleteCommand extends Command {
     public static final String COMMAND_WORD = "delete";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the person identified by the index number used in the displayed person list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
+            + ": Deletes the person identified by the index number used in the displayed person list.\n\n"
+            + "Parameters: INDEX (must be a positive integer)\n\n"
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";

--- a/src/main/java/seedu/address/logic/commands/DeleteContactedInfoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteContactedInfoCommand.java
@@ -30,12 +30,12 @@ public class DeleteContactedInfoCommand extends Command {
     public static final String COMMAND_WORD = "unlog";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes a contacted information from an existing contact, \n"
-            + "as specified by the index number used in the displayed person list.\n"
-            + "The log will be deleted only if "
-            + "the contacted information list is not empty.\n"
+            + ": Deletes a specified interaction record from an existing contact, "
+            + "as specified by the index number used in the displayed person list.\n\n"
+            + "The interaction record will be deleted only if "
+            + "there are interaction records.\n\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + PREFIX_DELETE_CONTACTED_INFO + "INDEX\n"
+            + PREFIX_DELETE_CONTACTED_INFO + "INDEX\n\n"
             + "Example: " + COMMAND_WORD + " 2 "
             + PREFIX_DELETE_CONTACTED_INFO + "1";
 

--- a/src/main/java/seedu/address/logic/commands/DeleteContactedInfoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteContactedInfoCommand.java
@@ -31,17 +31,17 @@ public class DeleteContactedInfoCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes a specified interaction record from an existing contact, "
-            + "as specified by the index number used in the displayed person list.\n\n"
+            + "as specified by the index number used in the displayed contact list.\n\n"
             + "The interaction record will be deleted only if "
             + "there are interaction records.\n\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + PREFIX_DELETE_CONTACTED_INFO + "INDEX\n\n"
+            + PREFIX_DELETE_CONTACTED_INFO + "INDEX (must be a positive integer)\n\n"
             + "Example: " + COMMAND_WORD + " 2 "
             + PREFIX_DELETE_CONTACTED_INFO + "1";
 
-    public static final String MESSAGE_DELETE_CONTACTED_INFO_SUCCESS = "Deleted contacted information: %1$s";
-    public static final String MESSAGE_INVALID_CONTACTED_INFO_INDEX = "The specified log entry does not exist.";
-    public static final String MESSAGE_EMPTY_CONTACTED_INFO_LIST = "Cannot delete, list is empty!";
+    public static final String MESSAGE_DELETE_CONTACTED_INFO_SUCCESS = "Deleted interaction record:\n%1$s";
+    public static final String MESSAGE_INVALID_CONTACTED_INFO_INDEX = "This interaction record does not exist.";
+    public static final String MESSAGE_EMPTY_CONTACTED_INFO_LIST = "Cannot delete, you have no interactions!";
 
     private final Index index;
     private final Index indexToDel;

--- a/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
@@ -32,9 +32,9 @@ public class DeleteTagCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes a tag from the tags of an existing contact, "
             + "as specified by the index number used in the displayed person list. The tag will be deleted only if "
-            + "the tag is valid and is tagged to the contact (case-insensitive).\n"
+            + "the tag is valid and is tagged to the contact (case-insensitive).\n\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + "[" + PREFIX_TAG + "TAG]\n"
+            + "[" + PREFIX_TAG + "TAG]\n\n"
             + "Example: " + COMMAND_WORD + " 2 "
             + PREFIX_TAG + "friends";
 

--- a/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
@@ -31,7 +31,7 @@ public class DeleteTagCommand extends Command {
     public static final String COMMAND_WORD = "untag";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes a tag from the tags of an existing contact, "
-            + "as specified by the index number used in the displayed person list. The tag will be deleted only if "
+            + "as specified by the index number used in the displayed contact list. The tag will be deleted only if "
             + "the tag is valid and is tagged to the contact (case-insensitive).\n\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_TAG + "TAG]\n\n"

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -39,13 +39,13 @@ public class EditCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Edits the details of the person identified "
             + "by the index number used in the displayed person list. "
-            + "Existing values will be overwritten by the input values.\n"
+            + "Existing values will be overwritten by the input values.\n\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
-            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "[" + PREFIX_TAG + "TAG]...\n\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com";

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTH_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
@@ -38,13 +39,14 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Edits the details of the person identified "
-            + "by the index number used in the displayed person list. "
+            + "by the index number used in the displayed contact list. "
             + "Existing values will be overwritten by the input values.\n\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
+            + "[" + PREFIX_BIRTH_DATE + "BIRTH_DATE] "
             + "[" + PREFIX_TAG + "TAG]...\n\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -9,7 +9,7 @@ public class ExitCommand extends Command {
 
     public static final String COMMAND_WORD = "exit";
 
-    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Address Book as requested ...";
+    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting AIA Application as requested ...";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -15,8 +15,8 @@ public class FindCommand extends Command {
     public static final String COMMAND_WORD = "find";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
 
     private final NameContainsKeywordsPredicate predicate;

--- a/src/main/java/seedu/address/logic/commands/HashtagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HashtagCommand.java
@@ -14,9 +14,9 @@ public class HashtagCommand extends Command {
 
     public static final String COMMAND_WORD = "#";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all contacts that is tagged to "
-            + "the specified tag (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: TAG\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all contacts tagged to "
+            + "the specified tag (case-insensitive) and displays them as a list with index numbers.\n\n"
+            + "Parameters: TAG\n\n"
             + "Example: " + COMMAND_WORD + "client";
 
     private final PersonWithTagPredicate predicate;

--- a/src/main/java/seedu/address/logic/commands/ListContactedInfoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListContactedInfoCommand.java
@@ -19,7 +19,7 @@ public class ListContactedInfoCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Lists all interaction records for a specified contact. \n\n"
             + "Parameters: "
-            + "INDEX\n\n"
+            + "INDEX (Must be a positive integer)\n\n"
             + "Example: " + COMMAND_WORD + " "
             + "3";
 

--- a/src/main/java/seedu/address/logic/commands/ListContactedInfoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListContactedInfoCommand.java
@@ -17,13 +17,13 @@ public class ListContactedInfoCommand extends Command {
     public static final String COMMAND_WORD = "logs";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Lists all contacted information for a specified contact. \n"
+            + ": Lists all interaction records for a specified contact. \n\n"
             + "Parameters: "
-            + "INDEX "
+            + "INDEX\n\n"
             + "Example: " + COMMAND_WORD + " "
             + "3";
 
-    public static final String MESSAGE_LIST_CONTACTED_INFO_SUCCESS = "Listed all contacted information for %1$s:\n%2$s";
+    public static final String MESSAGE_LIST_CONTACTED_INFO_SUCCESS = "Listed all interaction records for %1$s:\n%2$s";
 
     private final Index index;
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -48,7 +48,7 @@ public class AddressBookParser {
      * @return the command based on the user input
      * @throws ParseException if the user input does not conform the expected format
      */
-    public Command parseCommand(String userInput) throws ParseException, java.text.ParseException {
+    public Command parseCommand(String userInput) throws ParseException {
         final String trimmedUserInput = userInput.trim();
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(trimmedUserInput);
 

--- a/src/main/java/seedu/address/model/contactedinfo/ContactedInfo.java
+++ b/src/main/java/seedu/address/model/contactedinfo/ContactedInfo.java
@@ -88,10 +88,9 @@ public class ContactedInfo implements Comparable<ContactedInfo> {
      */
     @Override
     public String toString() {
-        return description.toString()
-                + " ("
-                + recentDate.toString()
-                + ")";
+        return "[" + recentDate.toString()
+                + "] "
+                + description.toString();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/tag/UniqueTagList.java
+++ b/src/main/java/seedu/address/model/tag/UniqueTagList.java
@@ -155,15 +155,9 @@ public class UniqueTagList implements ReadOnlyUniqueTagList {
         StringBuilder output = new StringBuilder();
         List<Tag> tagList = getUniqueTagList();
 
-        int count = 0;
         for (Tag tag : tagList) {
             output.append(tag);
-            count++;
-            if ((count % 5) == 0) {
-                output.append("\n");
-            } else {
-                output.append(" ");
-            }
+            output.append(" ");
         }
 
         String trimmedOutputString = output.toString().trim();

--- a/src/main/java/seedu/address/ui/StatusBarFooter.java
+++ b/src/main/java/seedu/address/ui/StatusBarFooter.java
@@ -22,7 +22,7 @@ public class StatusBarFooter extends UiPart<Region> {
      */
     public StatusBarFooter(Path saveLocation) {
         super(FXML);
-        saveLocationStatus.setText(Paths.get(".").resolve(saveLocation).toString());
+        saveLocationStatus.setText("Saved data available in: " + Paths.get("").resolve(saveLocation).toString());
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/AddContactedInfoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddContactedInfoCommandTest.java
@@ -100,7 +100,7 @@ public class AddContactedInfoCommandTest {
                 expectedPerson);
 
         String expectedMessage = String.format(
-                AddContactedInfoCommand.MESSAGE_ADD_CONTACTEDINFO_SUCCESS, expectedPerson);
+                AddContactedInfoCommand.MESSAGE_ADD_INTERACTION_SUCCESS, expectedPerson);
 
         assertCommandSuccess(contactedCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/AddContactedInfoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddContactedInfoCommandTest.java
@@ -100,7 +100,7 @@ public class AddContactedInfoCommandTest {
                 expectedPerson);
 
         String expectedMessage = String.format(
-                AddContactedInfoCommand.MESSAGE_ADD_INTERACTION_SUCCESS, expectedPerson);
+                AddContactedInfoCommand.MESSAGE_ADD_INTERACTION_SUCCESS, expectedPerson.getName(), contactedInfo);
 
         assertCommandSuccess(contactedCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/model/tag/UniqueTagListTest.java
+++ b/src/test/java/seedu/address/model/tag/UniqueTagListTest.java
@@ -136,7 +136,7 @@ public class UniqueTagListTest {
                 new Tag("test6")
         );
         uniqueTagList.addTags(tagSet);
-        String expectedString = "[test1] [test2] [test3] [test4] [test5]\n[test6]";
+        String expectedString = "[test1] [test2] [test3] [test4] [test5] [test6]";
         assertEquals(expectedString, uniqueTagList.toString());
 
         tagSet = Set.of(
@@ -146,12 +146,12 @@ public class UniqueTagListTest {
                 new Tag("test10")
         );
         uniqueTagList.addTags(tagSet);
-        expectedString = "[test1] [test10] [test2] [test3] [test4]\n[test5] [test6] [test7] [test8] [test9]";
+        expectedString = "[test1] [test10] [test2] [test3] [test4] [test5] [test6] [test7] [test8] [test9]";
         assertEquals(expectedString, uniqueTagList.toString());
 
         tagSet = Set.of(new Tag("test11"));
         uniqueTagList.addTags(tagSet);
-        expectedString = "[test1] [test10] [test11] [test2] [test3]\n[test4] [test5] [test6] [test7] [test8]\n[test9]";
+        expectedString = "[test1] [test10] [test11] [test2] [test3] [test4] [test5] [test6] [test7] [test8] [test9]";
         assertEquals(expectedString, uniqueTagList.toString());
     }
 }


### PR DESCRIPTION
The application is still showing output from v1.2, which may
confuse users.

To ensure the application is up to date with the changes to the
user guide, let's change the following to close AY2122S2-CS2103T-T17-3#122:
- Update command usage texts
- Remove deprecated parse exception from AddressBookParser and
LogicManager
- Update UniqueTagList
- Update StatusBarFooter
- Update MainApp logger messages