### PR TITLE
Add check for Description

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -105,7 +105,7 @@ e.g. "exe" refers to the executable file type used on windows.
   e.g. if you specify `p/12341234 p/56785678`, only `p/56785678` will be taken.
 
 * Dates should be in "YYYY-MM-DD" format, unless stated otherwise. Single digits should be zero padded.<br>
-  e.g. `2022-05-17`, `2021-01-01` and `2011-10-10` are in the correct format, while `2022-5-17` and `2021-1-1` are in the wrong format.
+  e.g. `2022-05-17`, `2021-01-01` and `2011-10-10` are in the correct format with zero padding, while `2022-5-17` and `2021-1-1` are in the wrong format as they do not have a zero padding for single digit months and/or days.
 * `INDEX` used in the different commands refer to the index number shown in the displayed person list.
 
   ❗The `INDEX` must be a positive integer i.e. 1,2,3,...

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -106,7 +106,7 @@ e.g. "exe" refers to the executable file type used on windows.
 
 * Dates should be in "YYYY-MM-DD" format, unless stated otherwise. Single digits should be zero padded.<br>
   e.g. `2022-05-17`, `2021-01-01` and `2011-10-10` are in the correct format with zero padding, while `2022-5-17` and `2021-1-1` are in the wrong format as they do not have a zero padding for single digit months and/or days.
-* `INDEX` used in the different commands refer to the index number shown in the displayed person list.
+* `INDEX` used in the different commands refer to the index number shown in the displayed contact list.
 
   ❗The `INDEX` must be a positive integer i.e. 1,2,3,...
 

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -72,6 +72,8 @@ public class StringUtil {
      * Will return false for any other non-null string input
      * e.g. empty string, "-1", "0", "+1", and " 2 " (untrimmed), "3 0" (contains whitespace), "1 a" (contains letters)
      *
+     * @param s String representing the integer to be parsed.
+     * @return a boolean if the string can be parsed as an unsigned integer.
      * @throws NullPointerException if {@code s} is null.
      */
     public static boolean isUnsignedInteger(String s) {
@@ -84,4 +86,19 @@ public class StringUtil {
         }
 
     }
+
+    /**
+     * Checks if {@code s} has a valid description length.
+     *
+     * @param s String containing a description.
+     * @return true if {@code s} is less than or equal to 280,
+     * otherwise false.
+     * @throws NullPointerException if {@code s} is null.
+     */
+    public static boolean isValidDescriptionLength(String s) {
+        requireNonNull(s);
+        return s.length() <= 280;
+    }
+
+
 }

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -22,6 +22,7 @@ public class AddCommand extends Command {
     public static final String COMMAND_WORD = "add";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Saves a person as a contact. "
+            + "Dates must be in the YYYY-MM-DD format."
             + "\n\nParameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_PHONE + "PHONE "

--- a/src/main/java/seedu/address/logic/commands/AddContactedInfoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddContactedInfoCommand.java
@@ -30,7 +30,9 @@ public class AddContactedInfoCommand extends Command {
             + "Existing date will be overwritten by the input.\n\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "d/ [DATE] "
-            + "des/ [DESCRIPTION]\n\n"
+            + "des/ [DESCRIPTION]"
+            + "\nDate must be in the YYYY-MM-DD format while Description must not exceed 280 characters"
+            + "\n\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + "d/ 2020-02-02 "
             + "des/ meetup.";

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -40,7 +40,9 @@ public class EditCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Edits the details of the person identified "
             + "by the index number used in the displayed contact list. "
-            + "Existing values will be overwritten by the input values.\n\n"
+            + "Existing values will be overwritten by the input values."
+            + "Dates must be in the YYYY-MM-DD format"
+            + "\n\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_PHONE + "PHONE] "
@@ -54,7 +56,7 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the data file.";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -56,7 +56,7 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the data file.";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the contact list.";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;

--- a/src/main/java/seedu/address/model/description/Description.java
+++ b/src/main/java/seedu/address/model/description/Description.java
@@ -3,6 +3,8 @@ package seedu.address.model.description;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import seedu.address.commons.util.StringUtil;
+
 /**
  * Represents a Person's description in the Contacted Date region.
  * Guarantees: immutable; is always valid
@@ -10,7 +12,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Description {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Description can take any values, and it should not be blank";
+            "Description can take any values, but must be within 280 characters and should not be blank";
 
     /*
      * The first character of the address must not be a whitespace,
@@ -32,14 +34,18 @@ public class Description {
     }
 
     /**
-     * Returns defulat description
+     * Returns a {@code Description} containing the string "First Interaction".
+     *
+     * @return a default {@code Description}.
      */
     public static Description defaultDesc() {
         return new Description("First Interaction");
     }
 
     /**
-     * Returns String representation of description.
+     * Returns the String representation of the {@code Description}.
+     *
+     * @return the {@code Description} in String.
      */
     @Override
     public String toString() {
@@ -47,10 +53,15 @@ public class Description {
     }
 
     /**
-     * Returns true if a given string is a valid description.
+     * Checks if the parsed String is a valid input.
+     *
+     * @return true if the input String matches the validation regex
+     * and if the length of the String does not exceed 280 characters,
+     * otherwise false.
      */
     public static boolean isValidDescription(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return test.matches(VALIDATION_REGEX)
+                && StringUtil.isValidDescriptionLength(test);
     }
 
 

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -45,6 +45,7 @@ public class StringUtilTest {
         assertTrue(StringUtil.isNonZeroUnsignedInteger("10"));
     }
 
+    //---------------- Tests for isUnsignedInteger --------------------------------------
     @Test
     public void isUnsignedInteger() {
 
@@ -78,6 +79,77 @@ public class StringUtilTest {
         assertTrue(StringUtil.isUnsignedInteger("10"));
     }
 
+    //---------------- Tests for isValidDescriptionLength --------------------------------------
+
+    /*
+     * Invalid equivalence partitions: null, Strings more than 280
+     * Valid equivalence partitions: String length of 0 to 280
+     */
+    @Test
+    public void isValidDescriptionLength() {
+        assertThrows(NullPointerException.class, ()-> StringUtil.isValidDescriptionLength(null));
+
+        //EP: 280 characters
+        assertTrue(StringUtil.isValidDescriptionLength("aaaaaaaaaaaaaaaa  "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaa"));
+
+        //EP: 281 characters
+        assertFalse(StringUtil.isValidDescriptionLength("aaaaaaaaaaaaaaaa  "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaa"));
+
+        //EP: 279 characters
+        assertTrue(StringUtil.isValidDescriptionLength("aaaaaaaaaaaaaaaa  "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaaaaaaaaaaaa "
+                + "aaaaaa"));
+
+        //EP: 0 characters, valid because we don't have a lower bound
+        assertTrue(StringUtil.isValidDescriptionLength(""));
+
+    }
 
     //---------------- Tests for containsWordIgnoreCase --------------------------------------
 

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -106,11 +106,11 @@ public class StringUtilTest {
                 + "aaaaaaaaaaaaaaaa "
                 + "aaaaaaaaaaaaaaaa "
                 + "aaaaaaaaaaaaaaaa "
-                + "aaaaaaa"));
+                + "a good."));
 
         //EP: 281 characters
         assertFalse(StringUtil.isValidDescriptionLength("aaaaaaaaaaaaaaaa  "
-                + "aaaaaaaaaaaaaaaa "
+                + "delete a lot aaa "
                 + "aaaaaaaaaaaaaaaa "
                 + "aaaaaaaaaaaaaaaa "
                 + "aaaaaaaaaaaaaaaa "


### PR DESCRIPTION
Description length for logs does not have an upper bound. This
opens up the application to possible exploits like exceedingly
long descriptions that will cause the application to slow down.

Let's do the following to close AY2122S2-CS2103T-T17-3#128:
- Add a check for ContactedInfo Decscriptions
- Add a format prompt for date in AddContactedInfoCommand Usage
- Add format prompts for other dates
- Update definition of zero-padded in user guide