### PR TITLE
Fix isValidEmail

### DIFF
--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -51,7 +51,8 @@ public class Email {
         if (!test.matches(VALIDATION_REGEX)) {
             return false;
         } else {
-            String[] spliced = test.split("@");
+            assert test.contains("@") :"email string does not have the '@' symbol";
+            String[] spliced = test.split("@",2);
             return spliced[1].contains(".");
         }
     }

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -51,8 +51,8 @@ public class Email {
         if (!test.matches(VALIDATION_REGEX)) {
             return false;
         } else {
-            assert test.contains("@") :"email string does not have the '@' symbol";
-            String[] spliced = test.split("@",2);
+            assert test.contains("@") : "email string does not have the '@' symbol";
+            String[] spliced = test.split("@", 2);
             return spliced[1].contains(".");
         }
     }

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -52,9 +52,6 @@ public class Email {
             return false;
         } else {
             String[] spliced = test.split("@");
-            System.out.println("spliced 0: " + spliced[0]);
-            System.out.println("spliced 0: " + spliced[1]);
-            System.out.println(spliced.length);
             return spliced[1].contains(".");
         }
     }

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -28,7 +28,7 @@ public class Email {
     private static final String DOMAIN_PART_REGEX = ALPHANUMERIC_NO_UNDERSCORE
             + "(-" + ALPHANUMERIC_NO_UNDERSCORE + ")*";
     private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + "){2,}$"; // At least two chars
-    private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)*" + DOMAIN_LAST_PART_REGEX;
+    private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)+" + DOMAIN_LAST_PART_REGEX;
     public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
 
     public final String value;
@@ -48,13 +48,7 @@ public class Email {
      * Returns if a given string is a valid email.
      */
     public static boolean isValidEmail(String test) {
-        if (!test.matches(VALIDATION_REGEX)) {
-            return false;
-        } else {
-            assert test.contains("@") : "email string does not have the '@' symbol";
-            String[] spliced = test.split("@", 2);
-            return spliced[1].contains(".");
-        }
+        return test.matches(VALIDATION_REGEX);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -48,7 +48,15 @@ public class Email {
      * Returns if a given string is a valid email.
      */
     public static boolean isValidEmail(String test) {
-        return test.matches(VALIDATION_REGEX);
+        if (!test.matches(VALIDATION_REGEX)) {
+            return false;
+        } else {
+            String[] spliced = test.split("@");
+            System.out.println("spliced 0: " + spliced[0]);
+            System.out.println("spliced 0: " + spliced[1]);
+            System.out.println(spliced.length);
+            return spliced[1].contains(".");
+        }
     }
 
     @Override

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -51,15 +51,18 @@ public class EmailTest {
         assertFalse(Email.isValidEmail("peterjack@-example.com")); // domain name starts with a hyphen
         assertFalse(Email.isValidEmail("peterjack@example.com-")); // domain name ends with a hyphen
         assertFalse(Email.isValidEmail("peterjack@example.c")); // top level domain has less than two chars
+        assertFalse(Email.isValidEmail("123@145")); // numeric local part and domain name
+        assertFalse(Email.isValidEmail("a@bc")); // minimal
+        assertFalse(Email.isValidEmail("test@localhost")); // alphabets only
 
         // valid email
+        assertTrue(Email.isValidEmail("PeterJack1190@example.com")); // standard case
         assertTrue(Email.isValidEmail("PeterJack_1190@example.com")); // underscore in local part
         assertTrue(Email.isValidEmail("PeterJack.1190@example.com")); // period in local part
         assertTrue(Email.isValidEmail("PeterJack+1190@example.com")); // '+' symbol in local part
         assertTrue(Email.isValidEmail("PeterJack-1190@example.com")); // hyphen in local part
-        assertTrue(Email.isValidEmail("a@bc")); // minimal
-        assertTrue(Email.isValidEmail("test@localhost")); // alphabets only
-        assertTrue(Email.isValidEmail("123@145")); // numeric local part and domain name
+        assertTrue(Email.isValidEmail("name@example.cn")); // top level domain has two chars
+        assertTrue(Email.isValidEmail("name@example.sg")); // top level domain has two chars
         assertTrue(Email.isValidEmail("a1+be.d@example1.com")); // mixture of alphanumeric and special characters
         assertTrue(Email.isValidEmail("peter_jack@very-very-very-long-example.com")); // long domain name
         assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@example.com")); // long local part


### PR DESCRIPTION
The application does not trigger the invalid email response when
users do not insert a period between domain name and domain label.

Let's do the following to close AY2122S2-CS2103T-T17-3#133:
- Fix isValidEmail method
- Edit tests for isValidEmail