### PR TITLE
Fix date related bugs

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -149,7 +149,11 @@ public class ParserUtil {
         if (!DocumentedDate.isValidDate(trimmedDate)) {
             throw new ParseException(DocumentedDate.MESSAGE_CONSTRAINTS);
         }
-        return BirthDate.parse(trimmedDate);
+        BirthDate newBirthDate = BirthDate.parse(trimmedDate);
+        if (newBirthDate.getDaysPassed() < 0) {
+            throw new ParseException(BirthDate.MESSAGE_CONSTRAINTS);
+        }
+        return newBirthDate;
     }
 
     /**

--- a/src/main/java/seedu/address/model/date/BirthDate.java
+++ b/src/main/java/seedu/address/model/date/BirthDate.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
 public class BirthDate extends DocumentedDate {
+    public static final String MESSAGE_CONSTRAINTS = "Birth dates cannot be in the future!";
     private static final DateTimeFormatter FORMATTER_INPUT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
     public final String value;
 

--- a/src/main/java/seedu/address/model/date/DocumentedDate.java
+++ b/src/main/java/seedu/address/model/date/DocumentedDate.java
@@ -6,13 +6,15 @@ import static java.util.Objects.requireNonNull;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.Locale;
 
 /**
  * Represents a DocumentedDate in the address book.
  */
 public class DocumentedDate {
     public static final String MESSAGE_CONSTRAINTS = "Dates should be in the format of YYYY-MM-DD";
-    private static final DateTimeFormatter FORMATTER_OUTPUT = DateTimeFormatter.ofPattern("dd MMM yyyy");
+    private static final DateTimeFormatter FORMATTER_OUTPUT =
+            DateTimeFormatter.ofPattern("dd MMM yyyy", Locale.ENGLISH);
     private LocalDate date;
 
     /**

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -38,7 +38,7 @@ import static seedu.address.testutil.TypicalPersons.DAVID;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddCommand;
-import seedu.address.model.date.BirthDate;
+import seedu.address.model.date.DocumentedDate;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -178,7 +178,7 @@ public class AddCommandParserTest {
                 parser,
                 NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + INVALID_BIRTH_DATE_DESC
                         + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
-                BirthDate.MESSAGE_CONSTRAINTS
+                DocumentedDate.MESSAGE_CONSTRAINTS
         );
 
         // invalid tag

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
-import seedu.address.model.date.BirthDate;
+import seedu.address.model.date.DocumentedDate;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -92,7 +92,7 @@ public class EditCommandParserTest {
         // invalid email
         assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS);
         // invalid birth date
-        assertParseFailure(parser, "1" + INVALID_BIRTH_DATE_DESC, BirthDate.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + INVALID_BIRTH_DATE_DESC, DocumentedDate.MESSAGE_CONSTRAINTS);
         // invalid address
         assertParseFailure(parser, "1" + INVALID_ADDRESS_DESC, Address.MESSAGE_CONSTRAINTS);
         // invalid tag

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -4,9 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_NUMBER_OF_DAYS;
+import static seedu.address.logic.parser.ParserUtil.parseBirthDate;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -15,6 +18,7 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.date.BirthDate;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -22,6 +26,8 @@ import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 
 public class ParserUtilTest {
+    private static final DateTimeFormatter FORMATTER_INPUT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
     private static final String INVALID_NAME = "R@chel";
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_ADDRESS = " ";
@@ -167,6 +173,31 @@ public class ParserUtilTest {
         String emailWithWhitespace = WHITESPACE + VALID_EMAIL + WHITESPACE;
         Email expectedEmail = new Email(VALID_EMAIL);
         assertEquals(expectedEmail, ParserUtil.parseEmail(emailWithWhitespace));
+    }
+
+    @Test
+    public void parseBirthDate_validBirthDate_returnsBirthDate() throws ParseException {
+        String expectedInput = "2000-01-01";
+        LocalDate expectedDate = LocalDate.parse(expectedInput);
+        BirthDate expectedBirthDate = new BirthDate(expectedDate);
+        assertEquals(expectedBirthDate, parseBirthDate(expectedInput));
+    }
+
+    // boundary value: current date is a valid birth date
+    @Test
+    public void parseBirthDate_currentDate_returnsBirthDate() throws ParseException {
+        LocalDate today = LocalDate.now();
+        String todayString = today.format(FORMATTER_INPUT);
+        BirthDate expectedBirthDate = new BirthDate(today);
+        assertEquals(expectedBirthDate, parseBirthDate(todayString));
+    }
+
+    // boundary value: one day in the future is not acceptable because it has not occurred
+    @Test
+    public void parseBirthDate_futureDate_throwsParseException() {
+        LocalDate tomorrow = LocalDate.now().plusDays(1);
+        String tomorrowString = tomorrow.format(FORMATTER_INPUT);
+        assertThrows(ParseException.class, ()->parseBirthDate(tomorrowString));
     }
 
     @Test


### PR DESCRIPTION
There is a bug where the user's local language will change the
displayed documented dates. Users are also able to add future
dates into the birth date field.

Let's do the following:
- Set display date locale to english to close AY2122S2-CS2103T-T17-3#134
- Add check for birth date field to close AY2122S2-CS2103T-T17-3#135