### PR TITLE
Add in-page hyperlinks to date format

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -125,12 +125,8 @@ When you meet a new potential client and you managed to get their contact inform
   * The default date would be the day the contact was added, and default description would be "First Interaction".
 
 Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS b/BIRTH_DATE [t/TAG]…​`
-<<<<<<< HEAD
 * `BIRTH_DATE` should be in the [specified date format](#a-date-format).
-=======
-* `BIRTH_DATE` should be in the specified date format.
 * `TAG` should be in the [specified format](#a-tag-name).
->>>>>>> master
 
 <div markdown="span" class="alert alert-primary">:bulb:
 **Tip:**

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -104,8 +104,9 @@ e.g. "exe" refers to the executable file type used on windows.
   the input will be taken.<br>
   e.g. if you specify `p/12341234 p/56785678`, only `p/56785678` will be taken.
 
-* Dates should be in "YYYY-MM-DD" format, unless stated otherwise. Single digits should be zero padded.<br>
+* <a name="a-date-format" />Dates should be in "YYYY-MM-DD" format, unless stated otherwise. Single digits should be zero padded.<br>
   e.g. `2022-05-17`, `2021-01-01` and `2011-10-10` are in the correct format with zero padding, while `2022-5-17` and `2021-1-1` are in the wrong format as they do not have a zero padding for single digit months and/or days.
+
 * `INDEX` used in the different commands refer to the index number shown in the displayed contact list.
 
   ❗The `INDEX` must be a positive integer i.e. 1,2,3,...
@@ -122,7 +123,7 @@ When you meet a new potential client and you managed to get their contact inform
   * The default date would be the day the contact was added, and default description would be "First Interaction".
 
 Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS b/BIRTH_DATE [t/TAG]…​`
-* `BIRTH_DATE` should be in the specified date format.
+* `BIRTH_DATE` should be in the [specified date format](#a-date-format).
 
 <div markdown="span" class="alert alert-primary">:bulb:
 **Tip:**
@@ -160,7 +161,7 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [b/BIRTH_DATE]
 * When editing tags, the existing tags of the person will be removed i.e. adding of tags is not cumulative.
 * You can remove all the person’s tags by typing `t/` without
   specifying any tags after it.
-* `BIRTH_DATE` should be in the specified date format.
+* `BIRTH_DATE` should be in the [specified date format](#a-date-format).
 
 Examples:
 * `edit 7 p/91234567 e/johndoe@example.com` edits the phone number and email address of the 1st person to be `91234567` and `johndoe@example.com` respectively.
@@ -255,7 +256,7 @@ Example:
 After meeting a client, you might want to write a note about the client, along with the meeting date. By using the `log` command, you can manually save your interaction with the person in the form of a note accompanied by a date.
 
 Format: `log INDEX d/DATE des/description`
-* `DATE` should be in the specified date format.
+* `DATE` should be in the [specified date format](#a-date-format).
 
 Example:
 * `log 6 d/2022-02-11 des/Signed contract` manually logs the following interaction with the 6th person in the displayed contact list, `Signed contract` on `2022-02-11`.
@@ -328,7 +329,7 @@ It is hard to keep track of everything all at once. Add a reminder for a client 
 * `INDEX` refers to the index number shown in the displayed contact list.
 
 Format: `remind INDEX r/REMINDER rd/DATE`
-* `DATE` should be in the specified date format.
+* `DATE` should be in the [specified date format](#a-date-format).
 
 Example:
 * `remind 1 r/sign contract rd/2022-04-02` sets up a reminder for you to make a phone call to the 1st person on 2 April 2022.
@@ -354,7 +355,7 @@ Example:
 If you just want to look at the tasks you need to do by a specific date, you can display all reminders due by a specified date.
 
 Format: `reminders [d/DATE]`
-* `DATE` should be in the specified date format.
+* `DATE` should be in the [specified date format](#a-date-format).
 
 Example:
 * `reminders d/2022-04-01` shows all reminders for 1 Apr 2022.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -161,11 +161,11 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [b/BIRTH_DATE]
 * Edits the person at the specified `INDEX`.
 * At least one of the optional fields must be provided.
 * Existing values will be updated to the input values.
+* `BIRTH_DATE` should be in the [specified date format](#a-date-format).
 * `TAG` should be in the [specified format](#a-tag-name).
 * When editing tags, the existing tags of the person will be removed i.e. adding of tags is not cumulative.
 * You can remove all the person’s tags by typing `t/` without
   specifying any tags after it.
-* `BIRTH_DATE` should be in the [specified date format](#a-date-format).
 
 Examples:
 * `edit 7 p/91234567 e/johndoe@example.com` edits the phone number and email address of the 1st person to be `91234567` and `johndoe@example.com` respectively.


### PR DESCRIPTION
"specified date format" is now hyperlinked to where the format was elaborated.

Test [here](https://github.com/ngjunkang/tp/blob/176-anchor-date-format/docs/UserGuide.md).

Closes #176.