### PR TITLE
ContactedInfo date can be before person's birthdate

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddContactedInfoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddContactedInfoCommand.java
@@ -22,7 +22,8 @@ public class AddContactedInfoCommand extends Command {
     public static final String MESSAGE_ADD_INTERACTION_SUCCESS = "Recorded interaction with %1$s"
             + "\n\nSaved interaction as:\n%2$s";
     public static final String MESSAGE_DUPLICATE_CONTACTED_INFO = "Interaction records already contains: %1$s";
-    public static final String MESSAGE_DATE_BEF_BIRTHDATE = "Interaction date cannot occur before %1$s";
+    public static final String MESSAGE_DATE_BEF_BIRTHDATE = "Interaction date cannot occur before person's "
+            + "birth date on %1$s";
     public static final String COMMAND_WORD = "log";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Adds the last contacted date  "

--- a/src/main/java/seedu/address/logic/commands/AddContactedInfoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddContactedInfoCommand.java
@@ -22,7 +22,7 @@ public class AddContactedInfoCommand extends Command {
     public static final String MESSAGE_ADD_INTERACTION_SUCCESS = "Recorded interaction with %1$s"
             + "\n\nSaved interaction as:\n%2$s";
     public static final String MESSAGE_DUPLICATE_CONTACTED_INFO = "Interaction records already contains: %1$s";
-
+    public static final String MESSAGE_DATE_BEF_BIRTHDATE = "Interaction date comes before person's birthdate: %1$s";
     public static final String COMMAND_WORD = "log";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Adds the last contacted date  "
@@ -75,6 +75,16 @@ public class AddContactedInfoCommand extends Command {
         if (personToEdit.containsContactedInfo(contactedInfo)) {
             throw new CommandException(String.format(MESSAGE_DUPLICATE_CONTACTED_INFO, contactedInfo.toString()));
         }
+
+        if (personToEdit.containsContactedInfo(contactedInfo)) {
+            throw new CommandException(String.format(MESSAGE_DUPLICATE_CONTACTED_INFO, contactedInfo.toString()));
+        }
+
+        if (contactedInfo.isBirthDateBefContacted(personToEdit.getBirthDate()) ) {
+            throw new CommandException(String.format(MESSAGE_DATE_BEF_BIRTHDATE,
+                    personToEdit.getBirthDate().toString()));
+        }
+
         ArrayList<ContactedInfo> updatedContactedInfo = new ArrayList<>(personToEdit.getContactedInfoList());
         updatedContactedInfo.add(contactedInfo);
         Collections.sort(updatedContactedInfo);

--- a/src/main/java/seedu/address/logic/commands/AddContactedInfoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddContactedInfoCommand.java
@@ -22,7 +22,7 @@ public class AddContactedInfoCommand extends Command {
     public static final String MESSAGE_ADD_INTERACTION_SUCCESS = "Recorded interaction with %1$s"
             + "\n\nSaved interaction as:\n%2$s";
     public static final String MESSAGE_DUPLICATE_CONTACTED_INFO = "Interaction records already contains: %1$s";
-    public static final String MESSAGE_DATE_BEF_BIRTHDATE = "Interaction date comes before person's birthdate: %1$s";
+    public static final String MESSAGE_DATE_BEF_BIRTHDATE = "Interaction date cannot occur before %1$s";
     public static final String COMMAND_WORD = "log";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Adds the last contacted date  "

--- a/src/main/java/seedu/address/logic/commands/AddContactedInfoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddContactedInfoCommand.java
@@ -76,10 +76,6 @@ public class AddContactedInfoCommand extends Command {
             throw new CommandException(String.format(MESSAGE_DUPLICATE_CONTACTED_INFO, contactedInfo.toString()));
         }
 
-        if (personToEdit.containsContactedInfo(contactedInfo)) {
-            throw new CommandException(String.format(MESSAGE_DUPLICATE_CONTACTED_INFO, contactedInfo.toString()));
-        }
-
         if (contactedInfo.isBirthDateBefContacted(personToEdit.getBirthDate()) ) {
             throw new CommandException(String.format(MESSAGE_DATE_BEF_BIRTHDATE,
                     personToEdit.getBirthDate().toString()));

--- a/src/main/java/seedu/address/model/contactedinfo/ContactedInfo.java
+++ b/src/main/java/seedu/address/model/contactedinfo/ContactedInfo.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.date.BirthDate;
 import seedu.address.model.date.DocumentedDate;
 import seedu.address.model.date.RecentDate;
 import seedu.address.model.description.Description;
@@ -78,6 +79,10 @@ public class ContactedInfo implements Comparable<ContactedInfo> {
         int daysPassed = recentDate.getDaysPassed();
         assert daysPassed >= 0 : "Days passed should not be less than 0";
         return daysPassed;
+    }
+
+    public boolean isBirthDateBefContacted(BirthDate birthdate) {
+        return birthdate.getDaysPassed() < recentDate.getDaysPassed();
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddContactedInfoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddContactedInfoCommandTest.java
@@ -51,10 +51,10 @@ public class AddContactedInfoCommandTest {
     public void execute_duplicateContactedInfo_throwsCommandException() {
         // same contacted information
         ContactedInfo contactedInfo = new ContactedInfo(RecentDate.parse("2020-02-02"), new Description("Wedding"));
-        Person personToAddTag = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person personToAddContacted = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
 
         // Alice must already have the contacted information
-        assertTrue(personToAddTag.containsContactedInfo(contactedInfo));
+        assertTrue(personToAddContacted.containsContactedInfo(contactedInfo));
 
         AddContactedInfoCommand addContactedInfoCommand = new AddContactedInfoCommand(
                 INDEX_FIRST_PERSON, contactedInfo);
@@ -67,6 +67,29 @@ public class AddContactedInfoCommandTest {
         addContactedInfoCommand = new AddContactedInfoCommand(INDEX_FIRST_PERSON, contactedInfo);
         expectedMessage = String.format(
                 AddContactedInfoCommand.MESSAGE_DUPLICATE_CONTACTED_INFO, contactedInfo.toString());
+        assertCommandFailure(addContactedInfoCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_contactedInfoBeforeBirthday_throwsCommandException() {
+        // contactedInfoWayBeforeBirthday
+        ContactedInfo contactedInfo = new ContactedInfo(RecentDate.parse("1990-02-02"), new Description("Wedding"));
+        Person personToAddContacted = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+
+        AddContactedInfoCommand addContactedInfoCommand = new AddContactedInfoCommand(
+                INDEX_FIRST_PERSON, contactedInfo);
+        String expectedMessage = String.format(
+                AddContactedInfoCommand.MESSAGE_DATE_BEF_BIRTHDATE, personToAddContacted.getBirthDate().toString());
+        assertCommandFailure(addContactedInfoCommand, model, expectedMessage);
+
+        // contactedInfoDayBeforeBirthday
+        contactedInfo = new ContactedInfo(RecentDate.parse("1999-12-31"), new Description("Wedding"));
+        personToAddContacted = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+
+        addContactedInfoCommand = new AddContactedInfoCommand(
+                INDEX_FIRST_PERSON, contactedInfo);
+        expectedMessage = String.format(
+                AddContactedInfoCommand.MESSAGE_DATE_BEF_BIRTHDATE, personToAddContacted.getBirthDate().toString());
         assertCommandFailure(addContactedInfoCommand, model, expectedMessage);
     }
 

--- a/src/test/java/seedu/address/model/description/DescriptionTest.java
+++ b/src/test/java/seedu/address/model/description/DescriptionTest.java
@@ -2,10 +2,36 @@ package seedu.address.model.description;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
 public class DescriptionTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Description(null));
+    }
+
+    @Test
+    public void constructor_invalidDescription_throwsIllegalArgumentException() {
+        String invalidDescription = "";
+        assertThrows(IllegalArgumentException.class, () -> new Description(invalidDescription));
+    }
+
+    @Test
+    public void isValidDescription() {
+        // null
+        assertThrows(NullPointerException.class, () -> Description.isValidDescription(null));
+
+        // invalid description
+        assertFalse(Description.isValidDescription("")); // empty string
+        assertFalse(Description.isValidDescription(" ")); // spaces only
+
+        // valid description
+        assertTrue(Description.isValidDescription("Wedding"));
+        assertTrue(Description.isValidDescription("Phone Call!"));
+    }
 
     @Test
     public void equals() {


### PR DESCRIPTION
This Commit resolves https://github.com/AY2122S2-CS2103T-T17-3/tp/issues/218.

Now, users cannot add a contacted date before person's birthdate.